### PR TITLE
Remove comand from operator container

### DIFF
--- a/config/operator.yaml
+++ b/config/operator.yaml
@@ -16,8 +16,6 @@ spec:
       containers:
         - name: knative-serving-operator
           image: github.com/knative/serving-operator/cmd/manager
-          command:
-          - knative-serving-operator
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE


### PR DESCRIPTION
This is overriding the exec reference ko creates