### PR TITLE
Update operator to install knative serving 0.7.0

### DIFF
--- a/cmd/manager/kodata/knative-serving/0.7.0.yaml
+++ b/cmd/manager/kodata/knative-serving/0.7.0.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   labels:
     istio-injection: enabled
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: knative-serving
 
 ---
@@ -13,7 +13,7 @@ metadata:
   labels:
     networking.knative.dev/certificate-provider: cert-manager
     serving.knative.dev/controller: "true"
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: knative-serving-certmanager
 rules:
 - apiGroups:
@@ -36,7 +36,7 @@ metadata:
   labels:
     networking.knative.dev/ingress-provider: istio
     serving.knative.dev/controller: "true"
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: knative-serving-istio
 rules:
 - apiGroups:
@@ -54,6 +54,22 @@ rules:
   - watch
 
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    autoscaling.knative.dev/metric-provider: custom-metrics
+    serving.knative.dev/release: "v0.7.0"
+  name: custom-metrics-server-resources
+rules:
+- apiGroups:
+  - custom.metrics.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+
+---
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -62,7 +78,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: knative-serving-admin
 rules: []
 ---
@@ -71,7 +87,7 @@ kind: ClusterRole
 metadata:
   labels:
     serving.knative.dev/controller: "true"
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: knative-serving-core
 rules:
 - apiGroups:
@@ -96,7 +112,7 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - endpoints/restricted  # Permission for RestrictedEndpointsAdmission
+  - endpoints/restricted
   verbs:
   - create
 - apiGroups:
@@ -183,7 +199,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: controller
   namespace: knative-serving
 
@@ -192,7 +208,41 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    serving.knative.dev/release: "v0.6.0"
+    autoscaling.knative.dev/metric-provider: custom-metrics
+    serving.knative.dev/release: "v0.7.0"
+  name: custom-metrics:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: knative-serving
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    autoscaling.knative.dev/metric-provider: custom-metrics
+    serving.knative.dev/release: "v0.7.0"
+  name: hpa-controller-custom-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: custom-metrics-server-resources
+subjects:
+- kind: ServiceAccount
+  name: horizontal-pod-autoscaler
+  namespace: kube-system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    serving.knative.dev/release: "v0.7.0"
   name: knative-serving-controller-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -204,12 +254,30 @@ subjects:
   namespace: knative-serving
 
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    autoscaling.knative.dev/metric-provider: custom-metrics
+    serving.knative.dev/release: "v0.7.0"
+  name: custom-metrics-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: knative-serving
+
+---
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   labels:
     networking.knative.dev/ingress-provider: istio
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: knative-ingress-gateway
   namespace: knative-serving
 spec:
@@ -237,7 +305,7 @@ kind: Gateway
 metadata:
   labels:
     networking.knative.dev/ingress-provider: istio
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: cluster-local-gateway
   namespace: knative-serving
 spec:
@@ -257,7 +325,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     knative.dev/crd-install: "true"
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: certificates.networking.internal.knative.dev
 spec:
   additionalPrinterColumns:
@@ -289,7 +357,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     knative.dev/crd-install: "true"
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: clusteringresses.networking.internal.knative.dev
 spec:
   additionalPrinterColumns:
@@ -319,7 +387,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     knative.dev/crd-install: "true"
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: configurations.serving.knative.dev
 spec:
   additionalPrinterColumns:
@@ -350,7 +418,13 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -382,7 +456,39 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     knative.dev/crd-install: "true"
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
+  name: ingresses.networking.internal.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
+  group: networking.internal.knative.dev
+  names:
+    categories:
+    - all
+    - knative-internal
+    - networking
+    kind: Ingress
+    plural: ingresses
+    shortNames:
+    - ing
+    singular: ingress
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    knative.dev/crd-install: "true"
+    serving.knative.dev/release: "v0.7.0"
   name: podautoscalers.autoscaling.internal.knative.dev
 spec:
   additionalPrinterColumns:
@@ -414,7 +520,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     knative.dev/crd-install: "true"
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: revisions.serving.knative.dev
 spec:
   additionalPrinterColumns:
@@ -444,7 +550,13 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -452,7 +564,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     knative.dev/crd-install: "true"
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: routes.serving.knative.dev
 spec:
   additionalPrinterColumns:
@@ -479,7 +591,13 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -487,7 +605,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     knative.dev/crd-install: "true"
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: services.serving.knative.dev
 spec:
   additionalPrinterColumns:
@@ -521,7 +639,13 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -529,10 +653,13 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     knative.dev/crd-install: "true"
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: serverlessservices.networking.internal.knative.dev
 spec:
   additionalPrinterColumns:
+  - JSONPath: .spec.mode
+    name: Mode
+    type: string
   - JSONPath: .status.serviceName
     name: ServiceName
     type: string
@@ -567,7 +694,7 @@ kind: Service
 metadata:
   labels:
     app: activator
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: activator-service
   namespace: knative-serving
 spec:
@@ -594,7 +721,7 @@ kind: Service
 metadata:
   labels:
     app: controller
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: controller
   namespace: knative-serving
 spec:
@@ -612,7 +739,7 @@ kind: Service
 metadata:
   labels:
     role: webhook
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: webhook
   namespace: knative-serving
 spec:
@@ -627,18 +754,18 @@ apiVersion: caching.internal.knative.dev/v1alpha1
 kind: Image
 metadata:
   labels:
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: queue-proxy
   namespace: knative-serving
 spec:
-  image: gcr.io/knative-releases/github.com/knative/serving/cmd/queue@sha256:1e40c99ff5977daa2d69873fff604c6d09651af1f9ff15aadf8849b3ee77ab45
+  image: gcr.io/knative-releases/github.com/knative/serving/cmd/queue@sha256:e007c0a78c541600466f88954deee65c517246a23345bfba45a7f212d09b8f3b
 
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: activator
   namespace: knative-serving
 spec:
@@ -649,11 +776,12 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         sidecar.istio.io/inject: "true"
       labels:
         app: activator
         role: activator
-        serving.knative.dev/release: "v0.6.0"
+        serving.knative.dev/release: "v0.7.0"
     spec:
       containers:
       - args:
@@ -670,7 +798,11 @@ spec:
               fieldPath: metadata.namespace
         - name: CONFIG_LOGGING_NAME
           value: config-logging
-        image: gcr.io/knative-releases/github.com/knative/serving/cmd/activator@sha256:f553b6cb7599f2f71190ddc93024952e22f2f55e97a3f38519d4d622fc751651
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        image: gcr.io/knative-releases/github.com/knative/serving/cmd/activator@sha256:57fe5f1a8b1d12f29fe9e3a904b00c7219e5ce5825d94f33339db929e92257db
         livenessProbe:
           httpGet:
             httpHeaders:
@@ -700,6 +832,8 @@ spec:
           requests:
             cpu: 20m
             memory: 60Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/config-logging
           name: config-logging
@@ -720,7 +854,7 @@ kind: Service
 metadata:
   labels:
     app: autoscaler
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: autoscaler
   namespace: knative-serving
 spec:
@@ -733,6 +867,10 @@ spec:
     port: 9090
     protocol: TCP
     targetPort: 9090
+  - name: custom-metrics
+    port: 443
+    protocol: TCP
+    targetPort: 8443
   selector:
     app: autoscaler
 
@@ -741,7 +879,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: autoscaler
   namespace: knative-serving
 spec:
@@ -752,26 +890,50 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         sidecar.istio.io/inject: "true"
       labels:
         app: autoscaler
-        serving.knative.dev/release: "v0.6.0"
+        serving.knative.dev/release: "v0.7.0"
     spec:
       containers:
-      - env:
+      - args:
+        - --secure-port=8443
+        - --cert-dir=/tmp
+        env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
         - name: CONFIG_LOGGING_NAME
           value: config-logging
-        image: gcr.io/knative-releases/github.com/knative/serving/cmd/autoscaler@sha256:3a466eaf05cd505338163322331ee8634c601204250fa639360ae3524756acc3
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        image: gcr.io/knative-releases/github.com/knative/serving/cmd/autoscaler@sha256:2c2370df2751741348e1cc456f31425cb2455c377ddb45d3f6c17e743fd63d78
+        livenessProbe:
+          httpGet:
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: autoscaler
+            path: /healthz
+            port: 8080
         name: autoscaler
         ports:
         - containerPort: 8080
           name: websocket
         - containerPort: 9090
           name: metrics
+        - containerPort: 8443
+          name: custom-metrics
+        readinessProbe:
+          httpGet:
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: autoscaler
+            path: /healthz
+            port: 8080
         resources:
           limits:
             cpu: 300m
@@ -779,6 +941,8 @@ spec:
           requests:
             cpu: 30m
             memory: 40Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/config-autoscaler
           name: config-autoscaler
@@ -822,10 +986,15 @@ data:
     # target percentage is how much of that maximum to use in a stable
     # state. E.g. if a Revision specifies ContainerConcurrency of 10, then
     # the Autoscaler will try to maintain 7 concurrent connections per pod
-    # on average. A value of 0.7 is chosen because the Autoscaler panics
+    # on average. A value of 70 is chosen because the Autoscaler panics
     # when concurrency exceeds 2x the desired set point. So we will panic
     # before we reach the limit.
-    container-concurrency-target-percentage: "1.0"
+    # For legacy and backwards compatibility reasons, this value also accepts
+    # fractional values in (0, 1] interval (i.e. 0.7 ⇒ 70%).
+    # Thus minimal percentage value must be greater than 1.0, or it will be
+    # treated as a fraction.
+    # TODO(#2016): Set to 70%.
+    container-concurrency-target-percentage: "100"
 
     # The container concurrency target default is what the Autoscaler will
     # try to maintain when the Revision specifies unlimited concurrency.
@@ -878,7 +1047,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: config-autoscaler
   namespace: knative-serving
 
@@ -919,7 +1088,7 @@ kind: ConfigMap
 metadata:
   labels:
     networking.knative.dev/certificate-provider: cert-manager
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: config-certmanager
   namespace: knative-serving
 
@@ -947,6 +1116,12 @@ data:
     # none is specified.
     revision-timeout-seconds: "300"  # 5 minutes
 
+    # max-revision-timeout-seconds contains the maximum number of
+    # seconds that can be used for revision-timeout-seconds.
+    # This value must be greater than or equal to revision-timeout-seconds.
+    # If omitted, the system default is used (600 seconds).
+    max-revision-timeout-seconds: "600"  # 10 minutes
+
     # revision-cpu-request contains the cpu allocation to assign
     # to revisions by default.  If omitted, no value is specified
     # and the system default is used.
@@ -966,10 +1141,17 @@ data:
     # revisions to by default.  If omitted, no value is specified
     # and the system default is used.
     revision-memory-limit: "200M"  # 200 megabytes of memory
+
+    # container-name-template contains a template for the default
+    # container name, if none is specified.  This field supports
+    # Go templating and is supplied with the ObjectMeta of the
+    # enclosing Service or Configuration, so values such as
+    # {{.Name}} are also valid.
+    container-name-template: "user-container"
 kind: ConfigMap
 metadata:
   labels:
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: config-defaults
   namespace: knative-serving
 
@@ -994,11 +1176,11 @@ data:
 
     # List of repositories for which tag to digest resolving should be skipped
     registriesSkippingTagResolving: "ko.local,dev.local"
-  queueSidecarImage: gcr.io/knative-releases/github.com/knative/serving/cmd/queue@sha256:1e40c99ff5977daa2d69873fff604c6d09651af1f9ff15aadf8849b3ee77ab45
+  queueSidecarImage: gcr.io/knative-releases/github.com/knative/serving/cmd/queue@sha256:e007c0a78c541600466f88954deee65c517246a23345bfba45a7f212d09b8f3b
 kind: ConfigMap
 metadata:
   labels:
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: config-deployment
   namespace: knative-serving
 
@@ -1044,7 +1226,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: config-domain
   namespace: knative-serving
 
@@ -1083,7 +1265,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: config-gc
   namespace: knative-serving
 
@@ -1120,11 +1302,15 @@ data:
     # is outside of the service mesh in that case, a cluster-local  service
     # will need to be exposed to a cluster-local gateway to be accessible.
     local-gateway.cluster-local-gateway: "cluster-local-gateway.istio-system.svc.cluster.local"
+
+    # To use only Istio service mesh and no cluster-local-gateway, replace
+    # all local-gateway.* entries the following entry.
+    local-gateway.mesh: "mesh"
 kind: ConfigMap
 metadata:
   labels:
     networking.knative.dev/ingress-provider: istio
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: config-istio
   namespace: knative-serving
 
@@ -1182,7 +1368,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: config-logging
   namespace: knative-serving
 
@@ -1266,8 +1452,17 @@ data:
     # entirely from the template. When choosing a new value be thoughtful
     # of the potential for conflicts - for example, when users choose to use
     # characters such as `-` in their service, or namespace, names.
-    #
+    # {{.Annotations}} can be used for any customization in the go template if needed.
+    # We strongly recommend keeping namespace part of the template to avoid domain name clashes
+    # Example '{{.Name}}-{{.Namespace}}.{{ index .Annotations "sub"}}.{{.Domain}}'
+    # and you have an annotation {"sub":"foo"}, then the generated template would be {Name}-{Namespace}.foo.{Domain}
     domainTemplate: "{{.Name}}.{{.Namespace}}.{{.Domain}}"
+
+    # tagTemplate specifies the golang text template string to use
+    # when constructing the DNS name for "tags" within the traffic blocks
+    # of Routes and Configuration.  This is used in conjunction with the
+    # domainTemplate above to determine the full URL for the tag.
+    tagTemplate: "{{.Name}}-{{.Tag}}"
 
     # Controls whether TLS certificates are automatically provisioned and
     # installed in the Knative ingress to terminate external TLS connection.
@@ -1285,7 +1480,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: config-network
   namespace: knative-serving
 
@@ -1309,60 +1504,9 @@ data:
     # to actually change the configuration.
 
     # logging.enable-var-log-collection defaults to false.
-    # A fluentd sidecar will be set up to collect var log if
+    # The fluentd daemon set will be set up to collect /var/log if
     # this flag is true.
     logging.enable-var-log-collection: false
-
-    # logging.fluentd-sidecar-image provides the fluentd sidecar image
-    # to inject as a sidecar to collect logs from /var/log.
-    # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
-
-    # logging.fluentd-sidecar-output-config provides the configuration
-    # for the fluentd sidecar, which will be placed into a configmap and
-    # mounted into the fluentd sidecar image.
-    logging.fluentd-sidecar-output-config: |
-      # Parse json log before sending to Elastic Search
-      <filter **>
-        @type parser
-        key_name log
-        <parse>
-          @type multi_format
-          <pattern>
-            format json
-            time_key fluentd-time # fluentd-time is reserved for structured logs
-            time_format %Y-%m-%dT%H:%M:%S.%NZ
-          </pattern>
-          <pattern>
-            format none
-            message_key log
-          </pattern>
-        </parse>
-      </filter>
-      # Send to Elastic Search
-      <match **>
-        @id elasticsearch
-        @type elasticsearch
-        @log_level info
-        include_tag_key true
-        # Elasticsearch service is in monitoring namespace.
-        host elasticsearch-logging.knative-monitoring
-        port 9200
-        logstash_format true
-        <buffer>
-          @type file
-          path /var/log/fluentd-buffers/kubernetes.system.buffer
-          flush_mode interval
-          retry_type exponential_backoff
-          flush_thread_count 2
-          flush_interval 5s
-          retry_forever
-          retry_max_interval 30
-          chunk_limit_size 2M
-          queue_limit_length 8
-          overflow_action block
-        </buffer>
-      </match>
 
     # logging.revision-url-template provides a template to use for producing the
     # logging URL that is injected into the status of each Revision.
@@ -1424,7 +1568,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: config-observability
   namespace: knative-serving
 
@@ -1462,7 +1606,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: config-tracing
   namespace: knative-serving
 
@@ -1471,7 +1615,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: controller
   namespace: knative-serving
 spec:
@@ -1485,7 +1629,7 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: controller
-        serving.knative.dev/release: "v0.6.0"
+        serving.knative.dev/release: "v0.7.0"
     spec:
       containers:
       - env:
@@ -1495,7 +1639,11 @@ spec:
               fieldPath: metadata.namespace
         - name: CONFIG_LOGGING_NAME
           value: config-logging
-        image: gcr.io/knative-releases/github.com/knative/serving/cmd/controller@sha256:8f402eab0ada038d3de2ad753a40f9f441715d08058d890537146bb0aba11c8e
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        image: gcr.io/knative-releases/github.com/knative/serving/cmd/controller@sha256:016c95f2d94be89683d1ddb7ea959667fd2d899087a4145a31d26b5d6f0bb38f
         name: controller
         ports:
         - containerPort: 9090
@@ -1507,6 +1655,8 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/config-logging
           name: config-logging
@@ -1517,12 +1667,30 @@ spec:
         name: config-logging
 
 ---
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  labels:
+    autoscaling.knative.dev/metric-provider: custom-metrics
+    serving.knative.dev/release: "v0.7.0"
+  name: v1beta1.custom.metrics.k8s.io
+spec:
+  group: custom.metrics.k8s.io
+  groupPriorityMinimum: 100
+  insecureSkipTLSVerify: true
+  service:
+    name: autoscaler
+    namespace: knative-serving
+  version: v1beta1
+  versionPriority: 100
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     networking.knative.dev/certificate-provider: cert-manager
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: networking-certmanager
   namespace: knative-serving
 spec:
@@ -1543,7 +1711,13 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/knative-releases/github.com/knative/serving/cmd/networking/certmanager@sha256:dc77db09a23103f64a554de4e01cfda7371cbb13bc0954c991bdc4141169257f
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        image: gcr.io/knative-releases/github.com/knative/serving/cmd/networking/certmanager@sha256:c757629165393f778d5c0e8b611c9c4857b24f0c748d985d3a080d0161a85248
         name: networking-certmanager
         ports:
         - containerPort: 9090
@@ -1555,6 +1729,8 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/config-logging
           name: config-logging
@@ -1570,7 +1746,7 @@ kind: Deployment
 metadata:
   labels:
     networking.knative.dev/ingress-provider: istio
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: networking-istio
   namespace: knative-serving
 spec:
@@ -1591,7 +1767,13 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/knative-releases/github.com/knative/serving/cmd/networking/istio@sha256:55fe9eeacfc20d97d3cd4f80bfc8a9b95cff7b5c50121bda87f754da8f05e57b
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        image: gcr.io/knative-releases/github.com/knative/serving/cmd/networking/istio@sha256:bb4407e4714511cd9429e86536c283265629a2c11c80633d91c0f798c494a16f
         name: networking-istio
         ports:
         - containerPort: 9090
@@ -1603,6 +1785,8 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/config-logging
           name: config-logging
@@ -1617,7 +1801,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    serving.knative.dev/release: "v0.6.0"
+    serving.knative.dev/release: "v0.7.0"
   name: webhook
   namespace: knative-serving
 spec:
@@ -1629,11 +1813,12 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         sidecar.istio.io/inject: "false"
       labels:
         app: webhook
         role: webhook
-        serving.knative.dev/release: "v0.6.0"
+        serving.knative.dev/release: "v0.7.0"
     spec:
       containers:
       - env:
@@ -1643,7 +1828,7 @@ spec:
               fieldPath: metadata.namespace
         - name: CONFIG_LOGGING_NAME
           value: config-logging
-        image: gcr.io/knative-releases/github.com/knative/serving/cmd/webhook@sha256:f0f98736bd4b55354f447f59183bf26b9be1ab01691b8b4aeee85caeb1166562
+        image: gcr.io/knative-releases/github.com/knative/serving/cmd/webhook@sha256:d9918d40492e0b20b48576ff6182e2ab896e50dfd2313cb471419be98f821b9c
         name: webhook
         resources:
           limits:
@@ -1652,6 +1837,8 @@ spec:
           requests:
             cpu: 20m
             memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/config-logging
           name: config-logging

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.6.0"
+	Version = "0.7.0"
 )


### PR DESCRIPTION
I validated this by deploying the old version of 0.6.0 using the operator and then deploying 0.7.0 using the operator on GKE.

I did not delete the 0.6.0 yaml files.