### PR TITLE
A simple script to run the operator locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ kubectl apply -f https://raw.githubusercontent.com/knative/serving/v0.6.0/third_
 
 ### Operator SDK
 
-This operator was created using the
-[operator-sdk](https://github.com/operator-framework/operator-sdk/). It's not
-strictly required but does provide some handy tooling.
+This operator was originally created using the
+[operator-sdk](https://github.com/operator-framework/operator-sdk/).
+It's not strictly required but does provide some handy tooling.
 
 ## The `KnativeServing` Custom Resource
 
@@ -87,26 +87,10 @@ The following command will build the operator and use your current "kube config"
 to connect to the cluster:
 
 ```
-operator-sdk up local --namespace=""
+./hack/run-local.sh
 ```
 
-Pass `--help` for further details on the various `operator-sdk` subcommands, and
-pass `--help` to the operator itself to see its available options:
-
-```
-operator-sdk up local --operator-flags "--help"
-```
-
-### Testing
-
-To run end-to-end tests against your cluster:
-
-```
-operator-sdk test local ./test/e2e --namespace default
-```
-
-The `--namespace` parameter must match that of the `ServiceAccount` subject in
-the [role_binding.yaml](config/role_binding.yaml).
+Pass `--help` for further details on the various subcommands
 
 ## Building the Operator Image
 

--- a/hack/run-local.sh
+++ b/hack/run-local.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DIR=${DIR:-$(cd $(dirname "$0")/.. && pwd)}
+
+export KO_DATA_PATH=${KO_DATA_PATH:-$DIR/cmd/manager/kodata}
+export WATCH_NAMESPACE=""
+
+go run $DIR/cmd/manager $@


### PR DESCRIPTION
This will pick up the default kubeconfig and run the operator outside
of the cluster as a remote client, handy for development:
```
  $ ./hack/run-local.sh --help
  $ ./hack/run-local.sh
  $ ./hack/run-local.sh --zap-devel
  $ ./hack/run-local.sh --zap-devel --zap-level info
```

I'm hoping the script can be converted to use the knative controller
when that drops.