### PR TITLE
Add a guide to use KO_DATA_PATH for operator-sdk up local

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The following command will build the operator and use your current "kube config"
 to connect to the cluster:
 
 ```
+export KO_DATA_PATH=cmd/manager/kodata/
 operator-sdk up local --namespace=""
 ```
 


### PR DESCRIPTION
This patch adds a guide to use KO_DATA_PATH for operator-sdk up local.

Fixes https://github.com/knative/serving-operator/issues/51