### PR TITLE
Update default CR with knative-serving namespace.

### DIFF
--- a/config/crds/serving_v1alpha1_knativeserving_cr.yaml
+++ b/config/crds/serving_v1alpha1_knativeserving_cr.yaml
@@ -2,6 +2,7 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: KnativeServing
 metadata:
   name: knative-serving
+  namespace: knative-serving
 spec:
   config:
     defaults:


### PR DESCRIPTION
knative-serving is the namespace used by the knativeserving controller to look
up the KnativeServing CR.

I'm not sure if there should be another change to add a namespace to knativeserving_controller: https://github.com/knative/serving-operator/blob/94e6137bb6df889c3a386435ab80a390ba66419b/pkg/controller/knativeserving/knativeserving_controller.go#L309.