### PR TITLE
Add ability to update the KnativeIngressGateway istio selector

### DIFF
--- a/config/crds/serving_v1alpha1_knativeserving_crd.yaml
+++ b/config/crds/serving_v1alpha1_knativeserving_crd.yaml
@@ -51,6 +51,15 @@ spec:
               description: A means to override the corresponding entries in the upstream
                 configmaps
               type: object
+            knative-ingress-gateway:
+              description: A means to override the knative-ingress-gateway
+              type: object
+              properties:
+                selector:
+                  description: The selector for the ingress-gateway.
+                  type: object
+                  additionalProperties:
+                    type: string
             registry:
               description: A means to override the corresponding deployment images in the upstream.
                 This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.

--- a/pkg/apis/serving/v1alpha1/knativeserving_types.go
+++ b/pkg/apis/serving/v1alpha1/knativeserving_types.go
@@ -45,6 +45,12 @@ type Registry struct {
 	Override map[string]string `json:"override,omitempty"`
 }
 
+// KnativeIngressGateway override the knative-ingress-gateway
+type KnativeIngressGateway struct {
+	// A map of values to replace the "selector" values in the knative-ingress-gateway.
+	Selector map[string]string `json:"selector,omitempty"`
+}
+
 // KnativeServingSpec defines the desired state of KnativeServing
 // +k8s:openapi-gen=true
 type KnativeServingSpec struct {
@@ -60,6 +66,9 @@ type KnativeServingSpec struct {
 	// If no registry is provided, the knative release images will be used.
 	// +optional
 	Registry Registry `json:"registry,omitempty"`
+
+	// A means to override the knative-ingress-gateway
+	KnativeIngressGateway KnativeIngressGateway `json:"knative-ingress-gateway,omitempty"`
 }
 
 // KnativeServingStatus defines the observed state of KnativeServing

--- a/pkg/controller/knativeserving/common/extensions.go
+++ b/pkg/controller/knativeserving/common/extensions.go
@@ -55,6 +55,7 @@ func (exts Extensions) Transform(scheme *runtime.Scheme, instance *servingv1alph
 		ConfigMapTransform(instance, log),
 		DeploymentTransform(scheme, instance, log),
 		ImageTransform(scheme, instance, log),
+		GatewayTransform(scheme, instance, log),
 	}
 	for _, extension := range exts {
 		result = append(result, extension.Transformers...)

--- a/pkg/controller/knativeserving/common/gateway.go
+++ b/pkg/controller/knativeserving/common/gateway.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	"github.com/go-logr/logr"
+	mf "github.com/jcrossley3/manifestival"
+	servingv1alpha1 "github.com/knative/serving-operator/pkg/apis/serving/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func GatewayTransform(scheme *runtime.Scheme, instance *servingv1alpha1.KnativeServing, log logr.Logger) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		// Update the deployment with the new registry and tag
+		if u.GetAPIVersion() == "networking.istio.io/v1alpha3" && u.GetKind() == "Gateway" && u.GetName() == "knative-ingress-gateway" {
+			return updateKnativeIngressGateway(scheme, instance, u)
+		}
+		return nil
+	}
+}
+
+func updateKnativeIngressGateway(scheme *runtime.Scheme, instance *servingv1alpha1.KnativeServing, u *unstructured.Unstructured) error {
+	gatewayOverrides := instance.Spec.KnativeIngressGateway
+	if len(gatewayOverrides.Selector) > 0 {
+		log.V(1).Info("Updating Gateway", "name", u.GetName(), "gatewayOverrides", gatewayOverrides)
+		unstructured.SetNestedStringMap(u.Object, gatewayOverrides.Selector, "spec", "selector")
+		log.V(1).Info("Finished conversion", "name", u.GetName(), "unstructured", u.Object)
+	}
+	return nil
+}

--- a/pkg/controller/knativeserving/common/gateway_test.go
+++ b/pkg/controller/knativeserving/common/gateway_test.go
@@ -1,0 +1,103 @@
+package common
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	servingv1alpha1 "github.com/knative/serving-operator/pkg/apis/serving/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/apis/istio/v1alpha3"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+type updateGatewayTest struct {
+	name           string
+	gatewayName    string
+	in             map[string]string
+	ingressGateway servingv1alpha1.KnativeIngressGateway
+	expected       map[string]string
+}
+
+var updateGatewayTests = []updateGatewayTest{
+	{
+		name:        "UpdatesKnativeIngressGateway",
+		gatewayName: "knative-ingress-gateway",
+		in: map[string]string{
+			"istio": "old-istio",
+		},
+		ingressGateway: servingv1alpha1.KnativeIngressGateway{
+			Selector: map[string]string{
+				"istio": "new-istio",
+			},
+		},
+		expected: map[string]string{
+			"istio": "new-istio",
+		},
+	},
+	{
+		name:        "DoesNothingToOtherGateway",
+		gatewayName: "not-knative-ingress-gateway",
+		in: map[string]string{
+			"istio": "old-istio",
+		},
+		ingressGateway: servingv1alpha1.KnativeIngressGateway{
+			Selector: map[string]string{
+				"istio": "new-istio",
+			},
+		},
+		expected: map[string]string{
+			"istio": "old-istio",
+		},
+	},
+}
+
+func TestGatewayTransform(t *testing.T) {
+	for _, tt := range updateGatewayTests {
+		t.Run(tt.name, func(t *testing.T) {
+			runGatewayTransformTest(t, &tt)
+		})
+	}
+}
+func runGatewayTransformTest(t *testing.T, tt *updateGatewayTest) {
+	log := logf.Log.WithName(tt.name)
+	logf.SetLogger(logf.ZapLogger(true))
+
+	testScheme := runtime.NewScheme()
+	unstructedGateway := makeUnstructuredGateway(t, tt, testScheme)
+	instance := &servingv1alpha1.KnativeServing{
+		Spec: servingv1alpha1.KnativeServingSpec{
+			KnativeIngressGateway: tt.ingressGateway,
+		},
+	}
+	gatewayTransform := GatewayTransform(testScheme, instance, log)
+	gatewayTransform(&unstructedGateway)
+	validateUnstructedGatewayChanged(t, tt, &unstructedGateway)
+}
+
+func validateUnstructedGatewayChanged(t *testing.T, tt *updateGatewayTest, u *unstructured.Unstructured) {
+	var gateway = &v1alpha3.Gateway{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, gateway)
+	assertEqual(t, err, nil)
+	for expectedKey, expectedValue := range tt.expected {
+		assertEqual(t, gateway.Spec.Selector[expectedKey], expectedValue)
+	}
+}
+
+func makeUnstructuredGateway(t *testing.T, tt *updateGatewayTest, scheme *runtime.Scheme) unstructured.Unstructured {
+	gateway := v1alpha3.Gateway{
+		Spec: v1alpha3.GatewaySpec{
+			Selector: tt.in,
+		},
+	}
+	gateway.APIVersion = "networking.istio.io/v1alpha3"
+	gateway.Kind = "Gateway"
+	gateway.Name = tt.gatewayName
+	unstructuredDeployment, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&gateway)
+	if err != nil {
+		t.Fatalf("Could not create unstructured deployment object: %v, err: %v", unstructuredDeployment, err)
+	}
+	return unstructured.Unstructured{
+		Object: unstructuredDeployment,
+	}
+}


### PR DESCRIPTION
Adds a new API to KnativeServing:
spec:
  knative-ingress-gateway:
    selector:
      istio: "new-istio-selector"

Fixes #50 