### PR TITLE
Add ability to ignore a KnativeServing CR.

### DIFF
--- a/config/crds/serving_v1alpha1_knativeserving_crd.yaml
+++ b/config/crds/serving_v1alpha1_knativeserving_crd.yaml
@@ -51,6 +51,10 @@ spec:
               description: A means to override the corresponding entries in the upstream
                 configmaps
               type: object
+            ignore:
+              description: A means to prevent installation of the knative services.
+                By default knative serving will be installed. Setting ignore to true, will cause the operator not to install knative serving.
+              type: boolean
             knative-ingress-gateway:
               description: A means to override the knative-ingress-gateway
               type: object

--- a/pkg/apis/serving/v1alpha1/knativeserving_types.go
+++ b/pkg/apis/serving/v1alpha1/knativeserving_types.go
@@ -67,6 +67,11 @@ type KnativeServingSpec struct {
 	// +optional
 	Registry Registry `json:"registry,omitempty"`
 
+	// A means to prevent installation of the knative services.
+	// By default knative serving will be installed. Setting ignore to true, will cause the operator not to install knative serving.
+	// +optional
+	Ignore bool `json:"ignore,omitempty"`
+
 	// A means to override the knative-ingress-gateway
 	KnativeIngressGateway KnativeIngressGateway `json:"knative-ingress-gateway,omitempty"`
 }

--- a/pkg/reconciler/knativeserving/knativeserving_controller.go
+++ b/pkg/reconciler/knativeserving/knativeserving_controller.go
@@ -157,6 +157,11 @@ func (r *ReconcileKnativeServing) Reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, r.ignore(instance)
 	}
 
+	if instance.Spec.Ignore {
+		reqLogger.V(1).Info("KnativeServing is intentionally ignored")
+		return reconcile.Result{}, r.itentionallyIgnore(instance)
+	}
+
 	stages := []func(*servingv1alpha1.KnativeServing) error{
 		r.initStatus,
 		r.install,
@@ -314,6 +319,12 @@ func (r *ReconcileKnativeServing) ignore(instance *servingv1alpha1.KnativeServin
 		err = r.updateStatus(instance)
 	}
 	return
+}
+
+// Reflect our ignorance in the KnativeServing status
+func (r *ReconcileKnativeServing) itentionallyIgnore(instance *servingv1alpha1.KnativeServing) (err error) {
+	instance.Status.MarkIgnored("Intentionally ignored")
+	return r.updateStatus(instance)
 }
 
 // If we can't find knative-serving/knative-serving, create it


### PR DESCRIPTION
This prevents the operator from mutating the knative serving installation state.
If knative serving is uninstalled, it will remain uninstalled.
If knative serving is installed, it will remain installed.

Addresses #39 