### PR TITLE
openshift: Introduce ServiceMonitor for OpenShift cluster

### DIFF
--- a/config/service_monitor.yaml
+++ b/config/service_monitor.yaml
@@ -1,0 +1,90 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: controller
+  annotations:
+    networkoperator.openshift.io/ignore-errors: ""
+  name: controller
+  namespace: knative-serving
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+  namespaceSelector:
+    matchNames:
+    - knative-serving
+  selector:
+    matchLabels:
+      app: controller
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: autoscaler
+  annotations:
+    networkoperator.openshift.io/ignore-errors: ""
+  name: autoscaler
+  namespace: knative-serving
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+  namespaceSelector:
+    matchNames:
+    - knative-serving
+  selector:
+    matchLabels:
+      app: autoscaler
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: activator
+  annotations:
+    networkoperator.openshift.io/ignore-errors: ""
+  name: activator
+  namespace: knative-serving
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+  namespaceSelector:
+    matchNames:
+    - knative-serving
+  selector:
+    matchLabels:
+      app: activator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: knative-serving
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: knative-serving
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/pkg/reconciler/knativeserving/openshift/openshift.go
+++ b/pkg/reconciler/knativeserving/openshift/openshift.go
@@ -26,6 +26,7 @@ import (
 
 	mf "github.com/jcrossley3/manifestival"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -53,7 +54,7 @@ var (
 	extension = common.Extension{
 		Transformers: []mf.Transformer{ingress, egress, deploymentController},
 		PreInstalls:  []common.Extender{ensureMaistra, caBundleConfigMap, addUserToSCC},
-		PostInstalls: []common.Extender{ensureOpenshiftIngress},
+		PostInstalls: []common.Extender{ensureOpenshiftIngress, installServiceMonitor},
 	}
 	log    = logf.Log.WithName("openshift")
 	api    client.Client
@@ -123,6 +124,12 @@ func istioExists(namespace string) (bool, error) {
 	)
 }
 
+func serviceMonitorExists(namespace string) (bool, error) {
+	return anyKindExists(api, namespace,
+		schema.GroupVersionKind{Group: "monitoring.coreos.com", Version: "v1", Kind: "servicemonitor"},
+	)
+}
+
 // ensureOpenshiftIngress ensures knative-openshift-ingress operator is installed
 func ensureOpenshiftIngress(instance *servingv1alpha1.KnativeServing) error {
 	namespace := instance.GetNamespace()
@@ -142,6 +149,53 @@ func ensureOpenshiftIngress(instance *servingv1alpha1.KnativeServing) error {
 		}
 	} else {
 		log.Error(err, "Unable to create Knative OpenShift Ingress operator install manifest")
+		return err
+	}
+	return nil
+}
+
+func installServiceMonitor(instance *servingv1alpha1.KnativeServing) error {
+	namespace := instance.GetNamespace()
+	log.Info("Installing ServiceMonitor")
+	const path = "config/service_monitor.yaml"
+
+	if serviceMonitorExists, err := serviceMonitorExists(namespace); err != nil {
+		return err
+	} else if !serviceMonitorExists {
+		log.Info("ServiceMonitor CRD is not installed. Skip to install ServiceMonitor")
+		return nil
+	}
+
+	// Add label openshift.io/cluster-monitoring to namespace
+	ns := &corev1.Namespace{}
+	if err := api.Get(context.TODO(), client.ObjectKey{Name: namespace}, ns); err != nil {
+		if !meta.IsNoMatchError(err) {
+			return err
+		}
+	}
+
+	const monitoringLabel = "openshift.io/cluster-monitoring"
+	ns.Labels[monitoringLabel] = "true"
+	if err := api.Update(context.TODO(), ns); err != nil {
+		log.Error(err, fmt.Sprintf("Could not add label %q to namespace %q", monitoringLabel, namespace))
+		return err
+	}
+
+	// Install ServiceMonitor
+	if manifest, err := mf.NewManifest(path, false, api); err == nil {
+		transforms := []mf.Transformer{mf.InjectOwner(instance)}
+		if len(namespace) > 0 {
+			transforms = append(transforms, mf.InjectNamespace(namespace))
+		}
+		if err = manifest.Transform(transforms...); err == nil {
+			err = manifest.ApplyAll()
+		}
+		if err != nil {
+			log.Error(err, "Unable to install ServiceMonitor")
+			return err
+		}
+	} else {
+		log.Error(err, "Unable to create ServiceMonitor install manifest")
 		return err
 	}
 	return nil


### PR DESCRIPTION
This patch introduces ServiceMonitor for OpenShift cluster.

OpenShift has a built-in monitoring stack and it has
[ServiceMonitor](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor) which defines monitoring for a set of services.

This PR introduces ServiceMonitor objects to montior services such as
`activator`, `autoscaler` and `controller` so that admin can view
these services's stats data via OpenShift built-in prometheus.

### Example steps for the usage

#### 0. Confirm `servicemonitors.monitoring.coreos.com` CRD is installed on OpenShift

```
$ oc get crd servicemonitors.monitoring.coreos.com
NAME                                    CREATED AT
servicemonitors.monitoring.coreos.com   2019-07-05T05:53:50Z
```

#### 1. Install serving operator

```
$ ./hack/run-local.sh
...
{"level":"info","ts":1562935115.9451315,"logger":"openshift","msg":"Installing ServiceMonitor"}
{"level":"info","ts":1562935116.1419318,"logger":"openshift","msg":"Detected","gvk":"monitoring.coreos.com/v1, Kind=servicemonitor"}
{"level":"info","ts":1562935116.7478926,"logger":"manifestival","msg":"Reading file","name":"config/service_monitor.yaml"}
{"level":"info","ts":1562935116.8441575,"logger":"manifestival","msg":"Creating","name":"knative-serving/controller","type":"monitoring.coreos.com/v1, Kind=ServiceMonitor"}
{"level":"info","ts":1562935117.0605907,"logger":"manifestival","msg":"Creating","name":"knative-serving/autoscaler","type":"monitoring.coreos.com/v1, Kind=ServiceMonitor"}
{"level":"info","ts":1562935117.2521946,"logger":"manifestival","msg":"Creating","name":"knative-serving/activator","type":"monitoring.coreos.com/v1, Kind=ServiceMonitor"}
{"level":"info","ts":1562935117.572637,"logger":"manifestival","msg":"Creating","name":"knative-serving/prometheus-k8s","type":"rbac.authorization.k8s.io/v1, Kind=Role"}
{"level":"info","ts":1562935117.9442976,"logger":"manifestival","msg":"Creating","name":"knative-serving/prometheus-k8s","type":"rbac.authorization.k8s.io/v1, Kind=RoleBinding"}
```

#### 2. Confirm the installation of ServiceMonitor

```
$ oc get servicemonitor -n knative-serving
NAME         AGE
activator    11m
autoscaler   11m
controller   11m
```

Also, namespace has `openshift.io/cluster-monitoring=true` label now.

```
$ oc get ns knative-serving --show-labels 
NAME              STATUS   AGE   LABELS
knative-serving   Active   4d    istio-injection=enabled,openshift.io/cluster-monitoring=true,serving.knative.dev/release=v0.7.0
```

#### 3. After a couple minutes later, we can see following metrics from OpenShift's monitoring stack.

![example1](https://user-images.githubusercontent.com/2138339/61133073-aa25eb80-a4f7-11e9-8c0b-76ded969ab58.png)

![target-example](https://user-images.githubusercontent.com/2138339/61133081-ad20dc00-a4f7-11e9-8eac-811bdcecdddd.png)
