### PR TITLE
Update the branch into client-go for the package jcrossley3/manifestival

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -409,12 +409,12 @@
   version = "v0.3.7"
 
 [[projects]]
-  branch = "master"
-  digest = "1:64609ee187eff61f8e4d2723f8fde9d0282ce19f8ad830528869f0f33a42ff39"
+  branch = "client-go"
+  digest = "1:1bb209138eba0d5a3121075ea078026a7cade304e2dab097786df6bd78c5ec8c"
   name = "github.com/jcrossley3/manifestival"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "78b6b04ae6ff35401397219bbbf0e97cd349712e"
+  revision = "2d595bb74f312fb5f9228ade0de5dbf792840061"
 
 [[projects]]
   digest = "1:1f2aebae7e7c856562355ec0198d8ca2fa222fb05e5b1b66632a1fce39631885"
@@ -1395,6 +1395,7 @@
     "k8s.io/client-go/rest",
     "k8s.io/client-go/testing",
     "k8s.io/client-go/tools/cache",
+    "k8s.io/client-go/tools/clientcmd",
     "k8s.io/client-go/util/flowcontrol",
     "k8s.io/code-generator/cmd/client-gen",
     "k8s.io/code-generator/cmd/conversion-gen",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -73,7 +73,7 @@ required = [
 
 [[constraint]]
   name = "github.com/jcrossley3/manifestival"
-  branch = "master"
+  branch = "client-go"
 
 [[constraint]]
   name = "knative.dev/pkg"

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/restmapper"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
+	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -111,6 +112,12 @@ func main() {
 
 	log.Info("Registering Components.")
 
+	clientConfig, err := clientcmd.BuildConfigFromFlags("", "")
+	if err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
 	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "")
@@ -118,7 +125,7 @@ func main() {
 	}
 
 	// Setup all Controllers
-	if err := reconciler.AddToManager(mgr); err != nil {
+	if err := reconciler.AddToManager(mgr, clientConfig); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}

--- a/pkg/reconciler/controller.go
+++ b/pkg/reconciler/controller.go
@@ -17,15 +17,16 @@ package reconciler
 
 import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	restclient "k8s.io/client-go/rest"
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-var AddToManagerFuncs []func(manager.Manager) error
+var AddToManagerFuncs []func(manager.Manager, *restclient.Config) error
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(m manager.Manager) error {
+func AddToManager(m manager.Manager, clientConfig *restclient.Config) error {
 	for _, f := range AddToManagerFuncs {
-		if err := f(m); err != nil {
+		if err := f(m, clientConfig); err != nil {
 			return err
 		}
 	}

--- a/pkg/reconciler/knativeserving/common/extensions.go
+++ b/pkg/reconciler/knativeserving/common/extensions.go
@@ -17,6 +17,7 @@ package common
 
 import (
 	mf "github.com/jcrossley3/manifestival"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/apimachinery/pkg/runtime"
 	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -25,7 +26,7 @@ import (
 
 var log = logf.Log.WithName("common")
 
-type Platforms []func(client.Client, *runtime.Scheme) (*Extension, error)
+type Platforms []func(client.Client, *runtime.Scheme, *restclient.Config) (*Extension, error)
 type Extender func(*servingv1alpha1.KnativeServing) error
 type Extensions []Extension
 type Extension struct {
@@ -34,9 +35,9 @@ type Extension struct {
 	PostInstalls []Extender
 }
 
-func (platforms Platforms) Extend(c client.Client, scheme *runtime.Scheme) (result Extensions, err error) {
+func (platforms Platforms) Extend(c client.Client, scheme *runtime.Scheme, clientConfig *restclient.Config) (result Extensions, err error) {
 	for _, fn := range platforms {
-		ext, err := fn(c, scheme)
+		ext, err := fn(c, scheme, clientConfig)
 		if err != nil {
 			return result, err
 		}

--- a/pkg/reconciler/knativeserving/minikube/minikube.go
+++ b/pkg/reconciler/knativeserving/minikube/minikube.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	mf "github.com/jcrossley3/manifestival"
+	restclient "k8s.io/client-go/rest"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -37,7 +38,7 @@ var (
 )
 
 // Configure minikube if we're soaking in it
-func Configure(c client.Client, _ *runtime.Scheme) (*common.Extension, error) {
+func Configure(c client.Client, _ *runtime.Scheme, clientConfig *restclient.Config) (*common.Extension, error) {
 	node := &v1.Node{}
 	if err := c.Get(context.TODO(), types.NamespacedName{Name: "minikube"}, node); err != nil {
 		if !errors.IsNotFound(err) {

--- a/vendor/github.com/jcrossley3/manifestival/manifestival.go
+++ b/vendor/github.com/jcrossley3/manifestival/manifestival.go
@@ -1,13 +1,16 @@
 package manifestival
 
 import (
-	"context"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
@@ -21,9 +24,9 @@ type Manifestival interface {
 	// Updates or creates a particular resource
 	Apply(*unstructured.Unstructured) error
 	// Deletes all resources in the manifest
-	DeleteAll(opts ...client.DeleteOptionFunc) error
+	DeleteAll(opts *metav1.DeleteOptions) error
 	// Deletes a particular resource
-	Delete(spec *unstructured.Unstructured, opts ...client.DeleteOptionFunc) error
+	Delete(spec *unstructured.Unstructured, opts *metav1.DeleteOptions) error
 	// Returns a copy of the resource from the api server, nil if not found
 	Get(spec *unstructured.Unstructured) (*unstructured.Unstructured, error)
 	// Transforms the resources within a Manifest
@@ -32,18 +35,27 @@ type Manifestival interface {
 
 type Manifest struct {
 	Resources []unstructured.Unstructured
-	client    client.Client
+	client    dynamic.Interface
+	mapper    meta.RESTMapper
 }
 
 var _ Manifestival = &Manifest{}
 
-func NewManifest(pathname string, recursive bool, client client.Client) (Manifest, error) {
-	log.Info("Reading file", "name", pathname)
+func NewManifest(pathname string, recursive bool, config *rest.Config) (Manifest, error) {
+	log.Info("Reading manifest", "name", pathname)
 	resources, err := Parse(pathname, recursive)
 	if err != nil {
 		return Manifest{}, err
 	}
-	return Manifest{Resources: resources, client: client}, nil
+	client, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return Manifest{Resources: resources}, err
+	}
+	mapper, err := apiutil.NewDiscoveryRESTMapper(config)
+	if err != nil {
+		return Manifest{Resources: resources}, err
+	}
+	return Manifest{Resources: resources, client: client, mapper: mapper}, nil
 }
 
 func (f *Manifest) ApplyAll() error {
@@ -60,17 +72,21 @@ func (f *Manifest) Apply(spec *unstructured.Unstructured) error {
 	if err != nil {
 		return err
 	}
+	resource, err := f.ResourceInterface(spec)
+	if err != nil {
+		return err
+	}
 	if current == nil {
 		logResource("Creating", spec)
 		annotate(spec, "manifestival", resourceCreated)
-		if err = f.client.Create(context.TODO(), spec.DeepCopy()); err != nil {
+		if _, err = resource.Create(spec.DeepCopy(), metav1.CreateOptions{}); err != nil {
 			return err
 		}
 	} else {
 		// Update existing one
 		if UpdateChanged(spec.UnstructuredContent(), current.UnstructuredContent()) {
 			logResource("Updating", spec)
-			if err = f.client.Update(context.TODO(), current); err != nil {
+			if _, err = resource.Update(current, metav1.UpdateOptions{}); err != nil {
 				return err
 			}
 		}
@@ -78,7 +94,7 @@ func (f *Manifest) Apply(spec *unstructured.Unstructured) error {
 	return nil
 }
 
-func (f *Manifest) DeleteAll(opts ...client.DeleteOptionFunc) error {
+func (f *Manifest) DeleteAll(opts *metav1.DeleteOptions) error {
 	a := make([]unstructured.Unstructured, len(f.Resources))
 	copy(a, f.Resources)
 	// we want to delete in reverse order
@@ -87,7 +103,7 @@ func (f *Manifest) DeleteAll(opts ...client.DeleteOptionFunc) error {
 	}
 	for _, spec := range a {
 		if okToDelete(&spec) {
-			if err := f.Delete(&spec, opts...); err != nil {
+			if err := f.Delete(&spec, opts); err != nil {
 				return err
 			}
 		}
@@ -95,13 +111,17 @@ func (f *Manifest) DeleteAll(opts ...client.DeleteOptionFunc) error {
 	return nil
 }
 
-func (f *Manifest) Delete(spec *unstructured.Unstructured, opts ...client.DeleteOptionFunc) error {
+func (f *Manifest) Delete(spec *unstructured.Unstructured, opts *metav1.DeleteOptions) error {
 	current, err := f.Get(spec)
 	if current == nil && err == nil {
 		return nil
 	}
+	resource, err := f.ResourceInterface(spec)
+	if err != nil {
+		return err
+	}
 	logResource("Deleting", spec)
-	if err := f.client.Delete(context.TODO(), spec, opts...); err != nil {
+	if err := resource.Delete(spec.GetName(), opts); err != nil {
 		// ignore GC race conditions triggered by owner references
 		if !errors.IsNotFound(err) {
 			return err
@@ -111,10 +131,11 @@ func (f *Manifest) Delete(spec *unstructured.Unstructured, opts ...client.Delete
 }
 
 func (f *Manifest) Get(spec *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-	key := client.ObjectKey{Namespace: spec.GetNamespace(), Name: spec.GetName()}
-	result := &unstructured.Unstructured{}
-	result.SetGroupVersionKind(spec.GroupVersionKind())
-	err := f.client.Get(context.TODO(), key, result)
+	resource, err := f.ResourceInterface(spec)
+	if err != nil {
+		return nil, err
+	}
+	result, err := resource.Get(spec.GetName(), metav1.GetOptions{})
 	if err != nil {
 		result = nil
 		if errors.IsNotFound(err) {
@@ -122,6 +143,18 @@ func (f *Manifest) Get(spec *unstructured.Unstructured) (*unstructured.Unstructu
 		}
 	}
 	return result, err
+}
+
+func (f *Manifest) ResourceInterface(spec *unstructured.Unstructured) (dynamic.ResourceInterface, error) {
+	gvk := spec.GroupVersionKind()
+	mapping, err := f.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return nil, err
+	}
+	if mapping.Scope.Name() == meta.RESTScopeNameRoot {
+		return f.client.Resource(mapping.Resource), nil
+	}
+	return f.client.Resource(mapping.Resource).Namespace(spec.GetNamespace()), nil
 }
 
 // We need to preserve the top-level target keys, specifically

--- a/vendor/github.com/jcrossley3/manifestival/yaml.go
+++ b/vendor/github.com/jcrossley3/manifestival/yaml.go
@@ -115,10 +115,10 @@ func decode(reader io.Reader) ([]unstructured.Unstructured, error) {
 	for {
 		out := unstructured.Unstructured{}
 		err = decoder.Decode(&out)
-		if err != nil {
+		if err == io.EOF {
 			break
 		}
-		if len(out.Object) == 0 {
+		if err != nil || len(out.Object) == 0 {
 			continue
 		}
 		objs = append(objs, out)


### PR DESCRIPTION
The purpose of this PR is to get rid of the usage of client.Client in controller-runtime.