### PR TITLE
golang format tools

### DIFF
--- a/pkg/reconciler/knativeserving/common/config_maps.go
+++ b/pkg/reconciler/knativeserving/common/config_maps.go
@@ -18,8 +18,8 @@ package common
 import (
 	"github.com/go-logr/logr"
 	mf "github.com/jcrossley3/manifestival"
-	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
 )
 
 func ConfigMapTransform(instance *servingv1alpha1.KnativeServing, log logr.Logger) mf.Transformer {

--- a/pkg/reconciler/knativeserving/common/extensions.go
+++ b/pkg/reconciler/knativeserving/common/extensions.go
@@ -17,8 +17,8 @@ package common
 
 import (
 	mf "github.com/jcrossley3/manifestival"
-	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
+	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )

--- a/pkg/reconciler/knativeserving/common/gateway.go
+++ b/pkg/reconciler/knativeserving/common/gateway.go
@@ -3,9 +3,9 @@ package common
 import (
 	"github.com/go-logr/logr"
 	mf "github.com/jcrossley3/manifestival"
-	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
 )
 
 func GatewayTransform(scheme *runtime.Scheme, instance *servingv1alpha1.KnativeServing, log logr.Logger) mf.Transformer {

--- a/pkg/reconciler/knativeserving/common/gateway_test.go
+++ b/pkg/reconciler/knativeserving/common/gateway_test.go
@@ -5,9 +5,9 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/apis/istio/v1alpha3"
+	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 

--- a/pkg/reconciler/knativeserving/common/images.go
+++ b/pkg/reconciler/knativeserving/common/images.go
@@ -22,12 +22,12 @@ import (
 	mf "github.com/jcrossley3/manifestival"
 
 	"github.com/go-logr/logr"
-	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	caching "knative.dev/caching/pkg/apis/caching/v1alpha1"
+	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
 )
 
 var (

--- a/pkg/reconciler/knativeserving/common/images_test.go
+++ b/pkg/reconciler/knativeserving/common/images_test.go
@@ -5,11 +5,11 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	caching "knative.dev/caching/pkg/apis/caching/v1alpha1"
+	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	appsv1 "k8s.io/api/apps/v1"

--- a/pkg/reconciler/knativeserving/minikube/minikube.go
+++ b/pkg/reconciler/knativeserving/minikube/minikube.go
@@ -19,12 +19,12 @@ import (
 	"context"
 
 	mf "github.com/jcrossley3/manifestival"
-	"knative.dev/serving-operator/pkg/reconciler/knativeserving/common"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/serving-operator/pkg/reconciler/knativeserving/common"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @mattmoor
