### PR TITLE
deployments should be created automatically as long as CR is present

### DIFF
--- a/pkg/reconciler/knativeserving/knativeserving_controller.go
+++ b/pkg/reconciler/knativeserving/knativeserving_controller.go
@@ -252,7 +252,9 @@ func (r *ReconcileKnativeServing) checkDeployments(instance *servingv1alpha1.Kna
 			if err := r.client.Get(context.TODO(), key, deployment); err != nil {
 				instance.Status.MarkDeploymentsNotReady()
 				if errors.IsNotFound(err) {
-					return nil
+					// maybe deployments deleted manually
+					log.Info("checkDeployments", u.GetName(), " not found, maybe deleted manually")
+					instance.Status.MarkInstallFailed("deployments missed")
 				}
 				return err
 			}


### PR DESCRIPTION
Fixed: #81 

mark instance status to installed failed if deployments are deleted manually after installed successfully


Signed-off-by: Wei Yu <yuweiw@cn.ibm.com>