### PR TITLE
Remove 'WATCH_NAMESPACE' functionality.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1368,7 +1368,6 @@
     "github.com/go-openapi/spec",
     "github.com/jcrossley3/manifestival",
     "github.com/openshift/api/config/v1",
-    "github.com/operator-framework/operator-sdk/pkg/k8sutil",
     "github.com/operator-framework/operator-sdk/pkg/leader",
     "github.com/operator-framework/operator-sdk/pkg/log/zap",
     "github.com/operator-framework/operator-sdk/pkg/metrics",

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -27,7 +27,6 @@ import (
 	"knative.dev/serving-operator/pkg/apis"
 	"knative.dev/serving-operator/pkg/reconciler"
 
-	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
@@ -76,12 +75,6 @@ func main() {
 
 	printVersion()
 
-	namespace, err := k8sutil.GetWatchNamespace()
-	if err != nil {
-		log.Error(err, "Failed to get watch namespace")
-		os.Exit(1)
-	}
-
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {
@@ -100,7 +93,6 @@ func main() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
-		Namespace:          namespace,
 		MapperProvider:     restmapper.NewDynamicRESTMapper,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 	})

--- a/config/operator.yaml
+++ b/config/operator.yaml
@@ -18,8 +18,6 @@ spec:
           image: knative.dev/serving-operator/cmd/manager
           imagePullPolicy: IfNotPresent
           env:
-            - name: WATCH_NAMESPACE
-              value: ""
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/hack/run-local.sh
+++ b/hack/run-local.sh
@@ -17,6 +17,5 @@
 DIR=${DIR:-$(cd $(dirname "$0")/.. && pwd)}
 
 export KO_DATA_PATH=${KO_DATA_PATH:-$DIR/cmd/manager/kodata}
-export WATCH_NAMESPACE=""
 
 go run $DIR/cmd/manager $@


### PR DESCRIPTION
WATCH_NAMESPACE is an artifact of operator-sdk. As we're moving over to pkg/controller, we don't need this anymore.