### PR TITLE
Add a pull-request template so we almost always automatically run /lint.

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,0 +1,23 @@
+<!--
+Request Prow to automatically lint any go code in this PR:
+
+/lint
+-->
+
+Fixes #
+
+## Proposed Changes
+
+*
+*
+*
+
+**Release Note**
+
+<!-- Enter your extended release note in the below block. If the PR requires
+additional action from users switching to the new release, include the string
+"action required". If no release note is required, write "NONE". -->
+
+```release-note
+
+```


### PR DESCRIPTION
We have these in other repos as well, so this makes things more even. it also includes running lint usually, to find out linting issues early.