### PR TITLE
golang format tools

### DIFF
--- a/test/clients.go
+++ b/test/clients.go
@@ -35,7 +35,7 @@ type Clients struct {
 
 // KnativeServingAlphaClients holds instances of interfaces for making requests to knativeserving clients
 type KnativeServingAlphaClients struct {
-	KnativeServings    servingv1alpha1.KnativeServingInterface
+	KnativeServings servingv1alpha1.KnativeServingInterface
 }
 
 // NewClients instantiates and returns several clientsets required for making request to the
@@ -88,7 +88,7 @@ func newKnativeServingAlphaClients(cfg *rest.Config, namespace string) (*Knative
 	}
 
 	return &KnativeServingAlphaClients{
-		KnativeServings:   cs.ServingV1alpha1().KnativeServings(namespace),
+		KnativeServings: cs.ServingV1alpha1().KnativeServings(namespace),
 	}, nil
 }
 

--- a/test/crd.go
+++ b/test/crd.go
@@ -18,5 +18,5 @@ package test
 
 // ResourceNames holds names of various resources.
 type ResourceNames struct {
-	KnativeServing        string
+	KnativeServing string
 }

--- a/test/resources/knativeserving.go
+++ b/test/resources/knativeserving.go
@@ -23,12 +23,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pkg/errors"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	va1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	va1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"github.com/pkg/errors"
 	"knative.dev/pkg/test/logging"
 	"knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving-operator/test"
@@ -78,7 +78,7 @@ func WaitForDeploymentAvailable(clients *test.Clients, name, namespace string, i
 	})
 
 	if waitErr != nil {
-		return dep, errors.Wrapf(waitErr, "Deployment %q is not in desired status for the condition type Available," +
+		return dep, errors.Wrapf(waitErr, "Deployment %q is not in desired status for the condition type Available,"+
 			"got: %+q; want %+q", name, getDeploymentStatus(dep), "True")
 	}
 


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @mattmoor
