### PR TITLE
Remove short-circuiting installation logic if we're in an installing state.

### DIFF
--- a/pkg/reconciler/knativeserving/knativeserving_controller.go
+++ b/pkg/reconciler/knativeserving/knativeserving_controller.go
@@ -201,9 +201,6 @@ func (r *ReconcileKnativeServing) updateStatus(instance *servingv1alpha1.Knative
 // Apply the embedded resources
 func (r *ReconcileKnativeServing) install(instance *servingv1alpha1.KnativeServing) error {
 	log.V(1).Info("install", "status", instance.Status)
-	if instance.Status.IsDeploying() {
-		return nil
-	}
 	defer r.updateStatus(instance)
 
 	extensions, err := platforms.Extend(r.client, r.kubeClientSet, r.dynamicClientSet, r.scheme)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

This piece of code is intended to prevent us from reapplying the full YAML if we're already in a deploying state. It can cause us to not recreate deployments though if we end up in an interim state, i.e. we're already in a deploying state and deployments start to vanish. We will never reconcile that in that case because this piece of code will always say that we're deploying and the checkDeployments code will never tell us something different.

Reapplying the YAML in any case is benign anyway. We can be smarter about this later and check the spec of what's already applied against the spec of the YAML in the file. That's purely a performance optimization though, correctness should not be affected by that.

/assign @houshengbo @jcrossley3 
