### PR TITLE
serving operator crashed during startup because connection to api server is not ready

### DIFF
--- a/config/operator.yaml
+++ b/config/operator.yaml
@@ -9,6 +9,8 @@ spec:
       name: knative-serving-operator
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         name: knative-serving-operator
     spec:


### PR DESCRIPTION
create DynamicRestMapper failed because kube apiserver couldn't be reached during startup.

Signed-off-by: Wei Yu <yuweiw@cn.ibm.com>
```
root@filmy1:/mnt/data/gowork/src/knative.dev/serving-operator# kubectl logs -f -c knative-serving-operator knative-serving-operator-7ff9bf4cd6-7zzqj
2019-08-08T08:07:00.112Z	ERROR	kubebuilder.manager	Failed to get API Group-Resources	{"error": "Get https://10.0.0.1:443/api?timeout=32s: dial tcp 10.0.0.1:443: connect: connection refused"}
knative.dev/serving-operator/vendor/github.com/go-logr/zapr.(*zapLogger).Error
	/mnt/data/gowork/src/knative.dev/serving-operator/vendor/github.com/go-logr/zapr/zapr.go:128
knative.dev/serving-operator/vendor/sigs.k8s.io/controller-runtime/pkg/manager.New
	/mnt/data/gowork/src/knative.dev/serving-operator/vendor/sigs.k8s.io/controller-runtime/pkg/manager/manager.go:173
main.main
	/mnt/data/gowork/src/knative.dev/serving-operator/cmd/manager/main.go:62
runtime.main
	/usr/local/go/src/runtime/proc.go:200
2019-08-08T08:07:00.112Z	ERROR	cmd		{"error": "Get https://10.0.0.1:443/api?timeout=32s: dial tcp 10.0.0.1:443: connect: connection refused"}
```
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #87 

## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```