### PR TITLE
Remove 'scheme'.

### DIFF
--- a/pkg/reconciler/knativeserving/common/extensions.go
+++ b/pkg/reconciler/knativeserving/common/extensions.go
@@ -17,7 +17,6 @@ package common
 
 import (
 	mf "github.com/jcrossley3/manifestival"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -27,15 +26,15 @@ var log = logf.Log.WithName("extensions")
 
 type Platforms []func(kubernetes.Interface) (mf.Transformer, error)
 
-func (platforms Platforms) Transformers(kubeClientSet kubernetes.Interface, scheme *runtime.Scheme, instance *servingv1alpha1.KnativeServing) ([]mf.Transformer, error) {
+func (platforms Platforms) Transformers(kubeClientSet kubernetes.Interface, instance *servingv1alpha1.KnativeServing) ([]mf.Transformer, error) {
 	log.V(1).Info("Transforming", "instance", instance)
 	result := []mf.Transformer{
 		mf.InjectOwner(instance),
 		mf.InjectNamespace(instance.GetNamespace()),
 		ConfigMapTransform(instance, log),
-		DeploymentTransform(scheme, instance, log),
-		ImageTransform(scheme, instance, log),
-		GatewayTransform(scheme, instance, log),
+		DeploymentTransform(instance, log),
+		ImageTransform(instance, log),
+		GatewayTransform(instance, log),
 	}
 	for _, fn := range platforms {
 		transformer, err := fn(kubeClientSet)

--- a/pkg/reconciler/knativeserving/common/gateway.go
+++ b/pkg/reconciler/knativeserving/common/gateway.go
@@ -4,26 +4,25 @@ import (
 	"github.com/go-logr/logr"
 	mf "github.com/jcrossley3/manifestival"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	servingv1alpha1 "knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
 )
 
-func GatewayTransform(scheme *runtime.Scheme, instance *servingv1alpha1.KnativeServing, log logr.Logger) mf.Transformer {
+func GatewayTransform(instance *servingv1alpha1.KnativeServing, log logr.Logger) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		// Update the deployment with the new registry and tag
 		if u.GetAPIVersion() == "networking.istio.io/v1alpha3" && u.GetKind() == "Gateway" {
 			if u.GetName() == "knative-ingress-gateway" {
-				return updateKnativeIngressGateway(scheme, instance.Spec.KnativeIngressGateway, u)
+				return updateKnativeIngressGateway(instance.Spec.KnativeIngressGateway, u)
 			}
 			if u.GetName() == "cluster-local-gateway" {
-				return updateKnativeIngressGateway(scheme, instance.Spec.ClusterLocalGateway, u)
+				return updateKnativeIngressGateway(instance.Spec.ClusterLocalGateway, u)
 			}
 		}
 		return nil
 	}
 }
 
-func updateKnativeIngressGateway(scheme *runtime.Scheme, gatewayOverrides servingv1alpha1.IstioGatewayOverride, u *unstructured.Unstructured) error {
+func updateKnativeIngressGateway(gatewayOverrides servingv1alpha1.IstioGatewayOverride, u *unstructured.Unstructured) error {
 	if len(gatewayOverrides.Selector) > 0 {
 		log.V(1).Info("Updating Gateway", "name", u.GetName(), "gatewayOverrides", gatewayOverrides)
 		unstructured.SetNestedStringMap(u.Object, gatewayOverrides.Selector, "spec", "selector")

--- a/pkg/reconciler/knativeserving/common/gateway_test.go
+++ b/pkg/reconciler/knativeserving/common/gateway_test.go
@@ -94,15 +94,14 @@ func runGatewayTransformTest(t *testing.T, tt *updateGatewayTest) {
 	log := logf.Log.WithName(tt.name)
 	logf.SetLogger(logf.ZapLogger(true))
 
-	testScheme := runtime.NewScheme()
-	unstructedGateway := makeUnstructuredGateway(t, tt, testScheme)
+	unstructedGateway := makeUnstructuredGateway(t, tt)
 	instance := &servingv1alpha1.KnativeServing{
 		Spec: servingv1alpha1.KnativeServingSpec{
 			KnativeIngressGateway: tt.knativeIngressGateway,
 			ClusterLocalGateway:   tt.clusterLocalGateway,
 		},
 	}
-	gatewayTransform := GatewayTransform(testScheme, instance, log)
+	gatewayTransform := GatewayTransform(instance, log)
 	gatewayTransform(&unstructedGateway)
 	validateUnstructedGatewayChanged(t, tt, &unstructedGateway)
 }
@@ -116,7 +115,7 @@ func validateUnstructedGatewayChanged(t *testing.T, tt *updateGatewayTest, u *un
 	}
 }
 
-func makeUnstructuredGateway(t *testing.T, tt *updateGatewayTest, scheme *runtime.Scheme) unstructured.Unstructured {
+func makeUnstructuredGateway(t *testing.T, tt *updateGatewayTest) unstructured.Unstructured {
 	gateway := v1alpha3.Gateway{
 		Spec: v1alpha3.GatewaySpec{
 			Selector: tt.in,

--- a/pkg/reconciler/knativeserving/common/images.go
+++ b/pkg/reconciler/knativeserving/common/images.go
@@ -35,27 +35,27 @@ var (
 	containerNameVariable = "${NAME}"
 )
 
-func DeploymentTransform(scheme *runtime.Scheme, instance *servingv1alpha1.KnativeServing, log logr.Logger) mf.Transformer {
+func DeploymentTransform(instance *servingv1alpha1.KnativeServing, log logr.Logger) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		// Update the deployment with the new registry and tag
 		if u.GetKind() == "Deployment" {
-			return updateDeployment(scheme, instance, u, log)
+			return updateDeployment(instance, u, log)
 		}
 		return nil
 	}
 }
 
-func ImageTransform(scheme *runtime.Scheme, instance *servingv1alpha1.KnativeServing, log logr.Logger) mf.Transformer {
+func ImageTransform(instance *servingv1alpha1.KnativeServing, log logr.Logger) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		// Update the image with the new registry and tag
 		if u.GetAPIVersion() == "caching.internal.knative.dev/v1alpha1" && u.GetKind() == "Image" {
-			return updateCachingImage(scheme, instance, u)
+			return updateCachingImage(instance, u)
 		}
 		return nil
 	}
 }
 
-func updateDeployment(scheme *runtime.Scheme, instance *servingv1alpha1.KnativeServing, u *unstructured.Unstructured, log logr.Logger) error {
+func updateDeployment(instance *servingv1alpha1.KnativeServing, u *unstructured.Unstructured, log logr.Logger) error {
 	var deployment = &appsv1.Deployment{}
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, deployment)
 	if err != nil {
@@ -99,7 +99,7 @@ func updateDeploymentImage(deployment *appsv1.Deployment, registry *servingv1alp
 	log.V(1).Info("Finished updating images", "name", deployment.GetName(), "containers", deployment.Spec.Template.Spec.Containers)
 }
 
-func updateCachingImage(scheme *runtime.Scheme, instance *servingv1alpha1.KnativeServing, u *unstructured.Unstructured) error {
+func updateCachingImage(instance *servingv1alpha1.KnativeServing, u *unstructured.Unstructured) error {
 	var image = &caching.Image{}
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, image)
 	if err != nil {

--- a/pkg/reconciler/knativeserving/common/images_test.go
+++ b/pkg/reconciler/knativeserving/common/images_test.go
@@ -105,14 +105,13 @@ func TestDeploymentTransform(t *testing.T) {
 func runDeploymentTransformTest(t *testing.T, tt *updateDeploymentImageTest) {
 	log := logf.Log.WithName(tt.name)
 	logf.SetLogger(logf.ZapLogger(true))
-	testScheme := runtime.NewScheme()
-	unstructuredDeployment := makeUnstructuredDeployment(t, tt, testScheme)
+	unstructuredDeployment := makeUnstructuredDeployment(t, tt)
 	instance := &servingv1alpha1.KnativeServing{
 		Spec: servingv1alpha1.KnativeServingSpec{
 			Registry: tt.registry,
 		},
 	}
-	deploymentTransform := DeploymentTransform(testScheme, instance, log)
+	deploymentTransform := DeploymentTransform(instance, log)
 	deploymentTransform(&unstructuredDeployment)
 	validateUnstructedDeploymentChanged(t, tt, &unstructuredDeployment)
 }
@@ -126,7 +125,7 @@ func validateUnstructedDeploymentChanged(t *testing.T, tt *updateDeploymentImage
 	}
 }
 
-func makeUnstructuredDeployment(t *testing.T, tt *updateDeploymentImageTest, scheme *runtime.Scheme) unstructured.Unstructured {
+func makeUnstructuredDeployment(t *testing.T, tt *updateDeploymentImageTest) unstructured.Unstructured {
 	deployment := appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "Deployment",
@@ -180,14 +179,13 @@ func runImageTransformTest(t *testing.T, tt *updateImageSpecTest) {
 	log := logf.Log.WithName(tt.name)
 	logf.SetLogger(logf.ZapLogger(true))
 
-	testScheme := runtime.NewScheme()
-	unstructuredImage := makeUnstructuredImage(t, tt, testScheme)
+	unstructuredImage := makeUnstructuredImage(t, tt)
 	instance := &servingv1alpha1.KnativeServing{
 		Spec: servingv1alpha1.KnativeServingSpec{
 			Registry: tt.registry,
 		},
 	}
-	imageTransform := ImageTransform(testScheme, instance, log)
+	imageTransform := ImageTransform(instance, log)
 	imageTransform(&unstructuredImage)
 	validateUnstructedImageChanged(t, tt, &unstructuredImage)
 }
@@ -199,7 +197,7 @@ func validateUnstructedImageChanged(t *testing.T, tt *updateImageSpecTest, u *un
 	assertEqual(t, image.Spec.Image, tt.expected)
 }
 
-func makeUnstructuredImage(t *testing.T, tt *updateImageSpecTest, scheme *runtime.Scheme) unstructured.Unstructured {
+func makeUnstructuredImage(t *testing.T, tt *updateImageSpecTest) unstructured.Unstructured {
 	image := caching.Image{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "caching.internal.knative.dev/v1alpha1",

--- a/pkg/reconciler/knativeserving/knativeserving_controller.go
+++ b/pkg/reconciler/knativeserving/knativeserving_controller.go
@@ -34,7 +34,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -63,7 +62,7 @@ func Add(mgr manager.Manager, clientConfig *rest.Config) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, clientConfig *rest.Config) reconcile.Reconciler {
-	return &ReconcileKnativeServing{client: mgr.GetClient(), scheme: mgr.GetScheme(), clientConfig: clientConfig}
+	return &ReconcileKnativeServing{client: mgr.GetClient(), clientConfig: clientConfig}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -102,7 +101,6 @@ type ReconcileKnativeServing struct {
 	kubeClientSet    kubernetes.Interface
 	dynamicClientSet dynamic.Interface
 	client           client.Client
-	scheme           *runtime.Scheme
 	config           mf.Manifest
 	clientConfig     *rest.Config
 }
@@ -202,7 +200,7 @@ func (r *ReconcileKnativeServing) install(instance *servingv1alpha1.KnativeServi
 
 // Transform the resources
 func (r *ReconcileKnativeServing) transform(instance *servingv1alpha1.KnativeServing) error {
-	transforms, err := platforms.Transformers(r.kubeClientSet, r.scheme, instance)
+	transforms, err := platforms.Transformers(r.kubeClientSet, instance)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

The `scheme` is used nowhere in our code today and I'd keep it that way.
