### PR TITLE
Format markdown

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -2,13 +2,15 @@
 
 This directory contains tests and testing docs for `Serving Operator`:
 
-- [Integration tests](#running-integration-tests) currently reside in [`/test/e2e`](./e2e)
+- [Integration tests](#running-integration-tests) currently reside in
+  [`/test/e2e`](./e2e)
 
 ## Running integration tests
 
-Before running the integration, please make sure you have installed `Serving Operator` by following
-the instruction [here](../README.md), and do not install custom resource for operator or knative-serving
-installed in your cluster.
+Before running the integration, please make sure you have installed
+`Serving Operator` by following the instruction [here](../README.md), and do not
+install custom resource for operator or knative-serving installed in your
+cluster.
 
 Create a namespace called `operator-tests` if it is missing.
 


### PR DESCRIPTION
Produced via:
  `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`
/assign @mattmoor
