### PR TITLE
Update manifestival to accept a logr.Logger

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -382,11 +382,11 @@
 
 [[projects]]
   branch = "client-go"
-  digest = "1:81d7c90d8779b1d1c11f919616b27ca9fdad600e20f63f7810a40cead3cfab9f"
+  digest = "1:928c48472d9006c89f70c696ea1f7cb829b38e410e0641ec3f434080c2a90896"
   name = "github.com/jcrossley3/manifestival"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "d4530429d4c0708da344a6ff5a63d7971d05b67b"
+  revision = "97e164e00f2355c8d3816d9006802224ba613a60"
 
 [[projects]]
   digest = "1:1f2aebae7e7c856562355ec0198d8ca2fa222fb05e5b1b66632a1fce39631885"

--- a/pkg/reconciler/knativeserving/knativeserving_controller.go
+++ b/pkg/reconciler/knativeserving/knativeserving_controller.go
@@ -110,6 +110,7 @@ type ReconcileKnativeServing struct {
 
 // Create manifestival resources and KnativeServing, if necessary
 func (r *ReconcileKnativeServing) InjectClient(c client.Client) error {
+	mf.SetLogger(log)
 	koDataDir := os.Getenv("KO_DATA_PATH")
 	m, err := mf.NewManifest(filepath.Join(koDataDir, "knative-serving/"), *recursive, r.clientConfig)
 	if err != nil {

--- a/vendor/github.com/jcrossley3/manifestival/manifestival.go
+++ b/vendor/github.com/jcrossley3/manifestival/manifestival.go
@@ -3,7 +3,10 @@ package manifestival
 import (
 	"fmt"
 
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
 	"github.com/operator-framework/operator-sdk/pkg/restmapper"
+	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -11,12 +14,13 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
-var (
-	log = logf.Log.WithName("manifestival")
-)
+var log = zapr.NewLogger(zap.NewExample())
+
+func SetLogger(l logr.Logger) {
+	log = l.WithName("manifestival")
+}
 
 type Manifestival interface {
 	// Either updates or creates all resources in the manifest


### PR DESCRIPTION
Fixes #147

This makes it possible to use https://github.com/go-logr/zapr to create a `logr.Logger` impl from `pkg/logging`