### PR TITLE
Add the verification of cluster-scoped resource deletion

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1273,6 +1273,7 @@
     "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/api/meta",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
     "k8s.io/apimachinery/pkg/labels",

--- a/test/clients.go
+++ b/test/clients.go
@@ -30,6 +30,7 @@ type Clients struct {
 	KubeClient                *test.KubeClient
 	Dynamic                   dynamic.Interface
 	KnativeServingAlphaClient servingv1alpha1.KnativeServingInterface
+	Config                    *rest.Config
 }
 
 // NewClients instantiates and returns several clientsets required for making request to the
@@ -61,6 +62,7 @@ func NewClients(configPath string, clusterName string, namespace string) (*Clien
 		return nil, err
 	}
 
+	clients.Config = cfg
 	return clients, nil
 }
 

--- a/test/config/0.8.0.yaml
+++ b/test/config/0.8.0.yaml
@@ -1,0 +1,1 @@
+../../cmd/manager/kodata/knative-serving/0.8.0.yaml

--- a/test/e2e/knativeservingdeployment_test.go
+++ b/test/e2e/knativeservingdeployment_test.go
@@ -157,13 +157,11 @@ func verifyClusterResourceDeletion(t *testing.T, clients *test.Clients) {
 		if u.GetNamespace() == "" && u.GetKind() != "Namespace" {
 			waitErr := wait.PollImmediate(resources.Interval, resources.Timeout, func() (bool, error) {
 				gvrs, _ := meta.UnsafeGuessKindToResource(u.GroupVersionKind())
-				if _, err := clients.Dynamic.Resource(gvrs).Get(u.GetName(), metav1.GetOptions{}); err != nil {
-					if apierrs.IsNotFound(err) {
-						return true, nil
-					}
+				if _, err := clients.Dynamic.Resource(gvrs).Get(u.GetName(), metav1.GetOptions{}); apierrs.IsNotFound(err) {
+					return true, nil
+				} else {
 					return false, err
 				}
-				return false, nil
 			})
 
 			if waitErr != nil {

--- a/test/e2e/knativeservingdeployment_test.go
+++ b/test/e2e/knativeservingdeployment_test.go
@@ -16,9 +16,13 @@ limitations under the License.
 package e2e
 
 import (
+	"path/filepath"
+	"runtime"
 	"testing"
 
+	mf "github.com/jcrossley3/manifestival"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/test/logstream"
@@ -60,6 +64,7 @@ func TestKnativeServingDeployment(t *testing.T) {
 	t.Run("delete", func(t *testing.T) {
 		knativeServingVerify(t, clients, names)
 		knativeServingDeletion(t, clients, names)
+		verifyClusterResourceDeletion(t, clients)
 	})
 }
 
@@ -126,8 +131,7 @@ func knativeServingDeletion(t *testing.T, clients *test.Clients, names test.Reso
 
 	for _, deployment := range dpList.Items {
 		waitErr := wait.PollImmediate(resources.Interval, resources.Timeout, func() (bool, error) {
-			_, err := clients.KubeClient.Kube.AppsV1().Deployments(deployment.Namespace).Get(deployment.Name, metav1.GetOptions{})
-			if err != nil {
+			if _, err := clients.KubeClient.Kube.AppsV1().Deployments(deployment.Namespace).Get(deployment.Name, metav1.GetOptions{}); err != nil {
 				if apierrs.IsNotFound(err) {
 					return true, nil
 				}
@@ -137,8 +141,35 @@ func knativeServingDeletion(t *testing.T, clients *test.Clients, names test.Reso
 		})
 
 		if waitErr != nil {
-			t.Fatalf("The deployment %s/%s failed to be deleted: %v", deployment.Namespace, deployment.Name, err)
+			t.Fatalf("The deployment %s/%s failed to be deleted: %v", deployment.Namespace, deployment.Name, waitErr)
 		}
 		t.Logf("The deployment %s/%s has been deleted.", deployment.Namespace, deployment.Name)
+	}
+}
+
+func verifyClusterResourceDeletion(t *testing.T, clients *test.Clients) {
+	_, b, _, _ := runtime.Caller(0)
+	m, err := mf.NewManifest(filepath.Join((filepath.Dir(b) + "/.."), "config/"), false, clients.Config)
+	if err != nil {
+		t.Fatal("Failed to load manifest", err)
+	}
+	for _, u := range m.Resources {
+		if u.GetNamespace() == "" && u.GetKind() != "Namespace" {
+			waitErr := wait.PollImmediate(resources.Interval, resources.Timeout, func() (bool, error) {
+				gvrs, _ := meta.UnsafeGuessKindToResource(u.GroupVersionKind())
+				if _, err := clients.Dynamic.Resource(gvrs).Get(u.GetName(), metav1.GetOptions{}); err != nil {
+					if apierrs.IsNotFound(err) {
+						return true, nil
+					}
+					return false, err
+				}
+				return false, nil
+			})
+
+			if waitErr != nil {
+				t.Fatalf("The %s %s failed to be deleted: %v", u.GetKind(), u.GetName(), waitErr)
+			}
+			t.Logf("The %s %s has been deleted.", u.GetKind(), u.GetName())
+		}
 	}
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #152

## Proposed Changes

* Add the verification of the cluster-scoped resource deletion, if the CR is deleted.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
