### PR TITLE
Only delete shared resources when last KS is deleted

### DIFF
--- a/pkg/reconciler/knativeserving/controller.go
+++ b/pkg/reconciler/knativeserving/controller.go
@@ -55,6 +55,7 @@ func NewController(
 	c := &Reconciler{
 		Base:                 rbase.NewBase(ctx, controllerAgentName, cmw),
 		knativeServingLister: knativeServingInformer.Lister(),
+		servings:             map[string]bool{},
 	}
 
 	koDataDir := os.Getenv("KO_DATA_PATH")

--- a/pkg/reconciler/knativeserving/controller.go
+++ b/pkg/reconciler/knativeserving/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/zapr"
 	mf "github.com/jcrossley3/manifestival"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"knative.dev/pkg/configmap"
@@ -55,7 +56,7 @@ func NewController(
 	c := &Reconciler{
 		Base:                 rbase.NewBase(ctx, controllerAgentName, cmw),
 		knativeServingLister: knativeServingInformer.Lister(),
-		servings:             map[string]bool{},
+		servings:             sets.String{},
 	}
 
 	koDataDir := os.Getenv("KO_DATA_PATH")

--- a/test/cleanup.go
+++ b/test/cleanup.go
@@ -40,7 +40,7 @@ func CleanupOnInterrupt(cleanup func()) {
 
 // TearDown will delete created names using clients.
 func TearDown(clients *Clients, names ResourceNames) {
-	if clients != nil && clients.KnativeServingAlphaClient != nil {
-		clients.KnativeServingAlphaClient.Delete(names.KnativeServing, &metav1.DeleteOptions{})
+	if clients != nil && clients.Serving != nil {
+		clients.KnativeServing().Delete(names.KnativeServing, &metav1.DeleteOptions{})
 	}
 }

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -26,11 +26,6 @@ import (
 
 // Setup creates the client objects needed in the e2e tests.
 func Setup(t *testing.T) *test.Clients {
-	return SetupWithNamespace(t)
-}
-
-// SetupWithNamespace creates the client objects needed in the e2e tests under the specified namespace.
-func SetupWithNamespace(t *testing.T) *test.Clients {
 	clients, err := test.NewClients(
 		pkgTest.Flags.Kubeconfig,
 		pkgTest.Flags.Cluster)

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -26,15 +26,14 @@ import (
 
 // Setup creates the client objects needed in the e2e tests.
 func Setup(t *testing.T) *test.Clients {
-	return SetupWithNamespace(t, test.ServingOperatorNamespace)
+	return SetupWithNamespace(t)
 }
 
 // SetupWithNamespace creates the client objects needed in the e2e tests under the specified namespace.
-func SetupWithNamespace(t *testing.T, namespace string) *test.Clients {
+func SetupWithNamespace(t *testing.T) *test.Clients {
 	clients, err := test.NewClients(
 		pkgTest.Flags.Kubeconfig,
-		pkgTest.Flags.Cluster,
-		namespace)
+		pkgTest.Flags.Cluster)
 	if err != nil {
 		t.Fatalf("Couldn't initialize clients: %v", err)
 	}


### PR DESCRIPTION
Fixes #154 

Strictly speaking, it doesn't address what it means to have multiple `KnativeServing` resources, because having them isn't necessarily a problem. The problem occurs when any one of them is deleted, at which point (prior to this change) all the cluster-scoped resources are deleted, thereby breaking all the remaining KS installations.

With this fix, the shared resources are only deleted when the last KS is deleted.