### PR TITLE
Adding support for imagePullSecrets

### DIFF
--- a/config/crds/serving_v1alpha1_knativeserving_crd.yaml
+++ b/config/crds/serving_v1alpha1_knativeserving_crd.yaml
@@ -83,6 +83,16 @@ spec:
                   type: object
                   additionalProperties:
                     type: string
+                imagePullSecrets:
+                  description: A list of secrets to be used when pulling the knative images. The secret must be created in the
+                    same namespace as the knative-serving deployments, and not the namespace of this resource.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        description: The name of the secret.
+                        type: string
           type: object
         status:
           description: Status defines the observed state of KnativeServing

--- a/pkg/apis/serving/v1alpha1/knativeserving_types.go
+++ b/pkg/apis/serving/v1alpha1/knativeserving_types.go
@@ -16,6 +16,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
@@ -43,6 +44,11 @@ type Registry struct {
 	// A map of a container name or image name to the full image location of the individual knative image.
 	// +optional
 	Override map[string]string `json:"override,omitempty"`
+
+	// A list of secrets to be used when pulling the knative images. The secret must be created in the
+	// same namespace as the knative-serving deployments, and not the namespace of this resource.
+	// +optional
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 }
 
 // IstioGatewayOverride override the knative-ingress-gateway and cluster-local-gateway

--- a/pkg/apis/serving/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/serving/v1alpha1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	apis "knative.dev/pkg/apis"
 )
@@ -177,6 +178,11 @@ func (in *Registry) DeepCopyInto(out *Registry) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.ImagePullSecrets != nil {
+		in, out := &in.ImagePullSecrets, &out.ImagePullSecrets
+		*out = make([]v1.LocalObjectReference, len(*in))
+		copy(*out, *in)
 	}
 	return
 }

--- a/pkg/reconciler/knativeserving/common/gateway_test.go
+++ b/pkg/reconciler/knativeserving/common/gateway_test.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package common
 
 import (

--- a/pkg/reconciler/knativeserving/common/images.go
+++ b/pkg/reconciler/knativeserving/common/images.go
@@ -149,11 +149,9 @@ func replaceName(imageTemplate string, name string) string {
 func updatePodImagePullSecrets(deployment *appsv1.Deployment, registry *servingv1alpha1.Registry, log *zap.SugaredLogger) {
 	if len(registry.ImagePullSecrets) > 0 {
 		log.Debugf("Adding ImagePullSecrets: %v", registry.ImagePullSecrets)
-		existingSecrets := deployment.Spec.Template.Spec.ImagePullSecrets
-		if len(existingSecrets) > 0 {
-			deployment.Spec.Template.Spec.ImagePullSecrets = append(existingSecrets, registry.ImagePullSecrets...)
-		} else {
-			deployment.Spec.Template.Spec.ImagePullSecrets = registry.ImagePullSecrets
-		}
+		deployment.Spec.Template.Spec.ImagePullSecrets = append(
+			deployment.Spec.Template.Spec.ImagePullSecrets,
+			registry.ImagePullSecrets...,
+		)
 	}
 }

--- a/pkg/reconciler/knativeserving/common/images.go
+++ b/pkg/reconciler/knativeserving/common/images.go
@@ -150,6 +150,10 @@ func updatePodImagePullSecrets(deployment *appsv1.Deployment, registry *servingv
 	if len(registry.ImagePullSecrets) > 0 {
 		log.Debugf("Adding ImagePullSecrets: %v", registry.ImagePullSecrets)
 		existingSecrets := deployment.Spec.Template.Spec.ImagePullSecrets
-		deployment.Spec.Template.Spec.ImagePullSecrets = append(registry.ImagePullSecrets, existingSecrets...)
+		if len(existingSecrets) > 0 {
+			deployment.Spec.Template.Spec.ImagePullSecrets = append(existingSecrets, registry.ImagePullSecrets...)
+		} else {
+			deployment.Spec.Template.Spec.ImagePullSecrets = registry.ImagePullSecrets
+		}
 	}
 }

--- a/pkg/reconciler/knativeserving/common/images.go
+++ b/pkg/reconciler/knativeserving/common/images.go
@@ -66,6 +66,7 @@ func updateDeployment(instance *servingv1alpha1.KnativeServing, u *unstructured.
 	log.Debugw("Updating Deployment", "name", u.GetName(), "registry", registry)
 
 	updateDeploymentImage(deployment, &registry, log)
+	updatePodImagePullSecrets(deployment, &registry, log)
 	err = updateUnstructured(u, deployment, log)
 	if err != nil {
 		return err
@@ -143,4 +144,12 @@ func updateContainer(container *corev1.Container, newImage string, log *zap.Suga
 
 func replaceName(imageTemplate string, name string) string {
 	return strings.ReplaceAll(imageTemplate, containerNameVariable, name)
+}
+
+func updatePodImagePullSecrets(deployment *appsv1.Deployment, registry *servingv1alpha1.Registry, log *zap.SugaredLogger) {
+	if len(registry.ImagePullSecrets) > 0 {
+		log.Debugf("Adding ImagePullSecrets: %v", registry.ImagePullSecrets)
+		existingSecrets := deployment.Spec.Template.Spec.ImagePullSecrets
+		deployment.Spec.Template.Spec.ImagePullSecrets = append(registry.ImagePullSecrets, existingSecrets...)
+	}
 }

--- a/pkg/reconciler/knativeserving/common/images_test.go
+++ b/pkg/reconciler/knativeserving/common/images_test.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package common
 
 import (

--- a/pkg/reconciler/knativeserving/common/images_test.go
+++ b/pkg/reconciler/knativeserving/common/images_test.go
@@ -253,8 +253,8 @@ var addImagePullSecretsTests = []addImagePullSecretsTest{
 			},
 		},
 		expectedSecrets: []corev1.LocalObjectReference{
-			corev1.LocalObjectReference{Name: "new-secret"},
 			corev1.LocalObjectReference{Name: "existing-secret"},
+			corev1.LocalObjectReference{Name: "new-secret"},
 		},
 	},
 }

--- a/pkg/reconciler/knativeserving/common/images_test.go
+++ b/pkg/reconciler/knativeserving/common/images_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"reflect"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -102,7 +103,7 @@ func TestDeploymentTransform(t *testing.T) {
 	}
 }
 func runDeploymentTransformTest(t *testing.T, tt *updateDeploymentImageTest) {
-	unstructuredDeployment := makeUnstructuredDeployment(t, tt)
+	unstructuredDeployment := makeUnstructured(t, makeDeployment(t, tt.name, corev1.PodSpec{Containers: tt.containers}))
 	instance := &servingv1alpha1.KnativeServing{
 		Spec: servingv1alpha1.KnativeServingSpec{
 			Registry: tt.registry,
@@ -122,28 +123,29 @@ func validateUnstructedDeploymentChanged(t *testing.T, tt *updateDeploymentImage
 	}
 }
 
-func makeUnstructuredDeployment(t *testing.T, tt *updateDeploymentImageTest) unstructured.Unstructured {
-	deployment := appsv1.Deployment{
+func makeDeployment(t *testing.T, name string, podSpec corev1.PodSpec) *appsv1.Deployment {
+	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: tt.name,
+			Name: name,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					Containers: tt.containers,
-				},
+				Spec: podSpec,
 			},
 		},
 	}
-	unstructuredDeployment, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&deployment)
+}
+
+func makeUnstructured(t *testing.T, obj interface{}) unstructured.Unstructured {
+	unstructuredObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&obj)
 	if err != nil {
-		t.Fatalf("Could not create unstructured deployment object: %v, err: %v", unstructuredDeployment, err)
+		t.Fatalf("Could not create unstructured object: %v, err: %v", unstructuredObject, err)
 	}
 	return unstructured.Unstructured{
-		Object: unstructuredDeployment,
+		Object: unstructuredObject,
 	}
 }
 
@@ -173,7 +175,7 @@ func TestImageTransform(t *testing.T) {
 	}
 }
 func runImageTransformTest(t *testing.T, tt *updateImageSpecTest) {
-	unstructuredImage := makeUnstructuredImage(t, tt)
+	unstructuredImage := makeUnstructured(t, makeImage(t, tt))
 	instance := &servingv1alpha1.KnativeServing{
 		Spec: servingv1alpha1.KnativeServingSpec{
 			Registry: tt.registry,
@@ -191,8 +193,8 @@ func validateUnstructedImageChanged(t *testing.T, tt *updateImageSpecTest, u *un
 	assertEqual(t, image.Spec.Image, tt.expected)
 }
 
-func makeUnstructuredImage(t *testing.T, tt *updateImageSpecTest) unstructured.Unstructured {
-	image := caching.Image{
+func makeImage(t *testing.T, tt *updateImageSpecTest) *caching.Image {
+	return &caching.Image{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "caching.internal.knative.dev/v1alpha1",
 			Kind:       "Image",
@@ -204,13 +206,82 @@ func makeUnstructuredImage(t *testing.T, tt *updateImageSpecTest) unstructured.U
 			Image: tt.in,
 		},
 	}
-	unstructuredDeployment, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&image)
-	if err != nil {
-		t.Fatalf("Could not create unstructured deployment object: %v, err: %v", unstructuredDeployment, err)
+}
+
+type addImagePullSecretsTest struct {
+	name            string
+	existingSecrets []corev1.LocalObjectReference
+	registry        servingv1alpha1.Registry
+	expectedSecrets []corev1.LocalObjectReference
+}
+
+var addImagePullSecretsTests = []addImagePullSecretsTest{
+	{
+		name:            "LeavesSecretsEmptyByDefault",
+		existingSecrets: nil,
+		registry:        servingv1alpha1.Registry{},
+		expectedSecrets: nil,
+	},
+	{
+		name:            "AddsImagePullSecrets",
+		existingSecrets: nil,
+		registry: servingv1alpha1.Registry{
+			ImagePullSecrets: []corev1.LocalObjectReference{corev1.LocalObjectReference{Name: "new-secret"}},
+		},
+		expectedSecrets: []corev1.LocalObjectReference{corev1.LocalObjectReference{Name: "new-secret"}},
+	},
+	{
+		name:            "SupportsMultipleImagePullSecrets",
+		existingSecrets: nil,
+		registry: servingv1alpha1.Registry{
+			ImagePullSecrets: []corev1.LocalObjectReference{
+				corev1.LocalObjectReference{Name: "new-secret-1"},
+				corev1.LocalObjectReference{Name: "new-secret-2"},
+			},
+		},
+		expectedSecrets: []corev1.LocalObjectReference{
+			corev1.LocalObjectReference{Name: "new-secret-1"},
+			corev1.LocalObjectReference{Name: "new-secret-2"},
+		},
+	},
+	{
+		name:            "MergesAdditionalSecretsWithAnyPreexisting",
+		existingSecrets: []corev1.LocalObjectReference{corev1.LocalObjectReference{Name: "existing-secret"}},
+		registry: servingv1alpha1.Registry{
+			ImagePullSecrets: []corev1.LocalObjectReference{
+				corev1.LocalObjectReference{Name: "new-secret"},
+			},
+		},
+		expectedSecrets: []corev1.LocalObjectReference{
+			corev1.LocalObjectReference{Name: "new-secret"},
+			corev1.LocalObjectReference{Name: "existing-secret"},
+		},
+	},
+}
+
+func TestImagePullSecrets(t *testing.T) {
+	for _, tt := range addImagePullSecretsTests {
+		t.Run(tt.name, func(t *testing.T) {
+			runImagePullSecretsTest(t, &tt)
+		})
 	}
-	return unstructured.Unstructured{
-		Object: unstructuredDeployment,
+}
+
+func runImagePullSecretsTest(t *testing.T, tt *addImagePullSecretsTest) {
+	unstructuredDeployment := makeUnstructured(t, makeDeployment(t, tt.name, corev1.PodSpec{ImagePullSecrets: tt.existingSecrets}))
+	instance := &servingv1alpha1.KnativeServing{
+		Spec: servingv1alpha1.KnativeServingSpec{
+			Registry: tt.registry,
+		},
 	}
+	deploymentTransform := DeploymentTransform(instance, log)
+	deploymentTransform(&unstructuredDeployment)
+
+	var deployment = &appsv1.Deployment{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredDeployment.Object, deployment)
+
+	assertEqual(t, err, nil)
+	assertDeepEqual(t, deployment.Spec.Template.Spec.ImagePullSecrets, tt.expectedSecrets)
 }
 
 func assertEqual(t *testing.T, actual, expected interface{}) {
@@ -218,4 +289,11 @@ func assertEqual(t *testing.T, actual, expected interface{}) {
 		return
 	}
 	t.Fatalf("expected does not equal actual. \nExpected: %v\nActual: %v", expected, actual)
+}
+
+func assertDeepEqual(t *testing.T, actual, expected interface{}) {
+	if reflect.DeepEqual(actual, expected) {
+		return
+	}
+	t.Fatalf("expected does not deep equal actual. \nExpected: %T %+v\nActual:   %T %+v", expected, expected, actual, actual)
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #124 

## Proposed Changes

* Adds support for specifying imagePullSecrets for a private registry.
* The secrets are specified in the same format they would be on a Deployment
* The secret needs to be created in the knative-serving namespace in order to work

I attempted to minimize duplication in the tests by doing a small amount of refactoring as I was reusing examples.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add support for providing imagePullSecrets when using a private registry for the knative images.
```
