### PR TITLE
Fix generate-yamls error by Ignoring grep error

### DIFF
--- a/hack/generate-yamls.sh
+++ b/hack/generate-yamls.sh
@@ -68,4 +68,5 @@ ko resolve ${KO_YAML_FLAGS} -f config/ > "${SERVING_OPERATOR_YAML}"
 # List generated YAML files. We have only one serving-operator.yaml so far.
 
 ls -1 ${SERVING_OPERATOR_YAML} > ${YAML_LIST_FILE}
-ls -1 ${YAML_OUTPUT_DIR}/*.yaml | grep -v ${SERVING_OPERATOR_YAML} >> ${YAML_LIST_FILE}
+# grep return 1 if there is no match, appending || true to avoid failure
+ls -1 ${YAML_OUTPUT_DIR}/*.yaml | grep -v ${SERVING_OPERATOR_YAML} >> ${YAML_LIST_FILE} || true


### PR DESCRIPTION
grep returns 1 if there is no match, which is the case since there is only 1 file generated, which was negated by `-v`. Fixing it by ignoring grep error

/cc @k4leung4 