### PR TITLE
Set the default GroupVersionKind for KnativeServing

### DIFF
--- a/pkg/apis/serving/v1alpha1/knativeserving_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/knativeserving_lifecycle.go
@@ -27,7 +27,7 @@ var conditions = apis.NewLivingConditionSet(
 
 // GroupVersionKind returns SchemeGroupVersion of a KnativeServing
 func (ks *KnativeServing) GroupVersionKind() schema.GroupVersionKind {
-	return SchemeGroupVersion.WithKind("KnativeServing")
+	return SchemeGroupVersion.WithKind(Kind)
 }
 
 // GetConditions implements apis.ConditionsAccessor

--- a/pkg/apis/serving/v1alpha1/knativeserving_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/knativeserving_lifecycle.go
@@ -16,6 +16,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
 )
 
@@ -23,6 +24,11 @@ var conditions = apis.NewLivingConditionSet(
 	DeploymentsAvailable,
 	InstallSucceeded,
 )
+
+// GroupVersionKind returns SchemeGroupVersion of a KnativeServing
+func (ks *KnativeServing) GroupVersionKind() schema.GroupVersionKind {
+	return SchemeGroupVersion.WithKind("KnativeServing")
+}
 
 // GetConditions implements apis.ConditionsAccessor
 func (is *KnativeServingStatus) GetConditions() apis.Conditions {

--- a/pkg/apis/serving/v1alpha1/knativeserving_lifecycle_test.go
+++ b/pkg/apis/serving/v1alpha1/knativeserving_lifecycle_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package v1alpha1
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestKnativeServingGroupVersionKind(t *testing.T) {
+	r := &KnativeServing{}
+	want := schema.GroupVersionKind{
+		Group:   GroupName,
+		Version: SchemaVersion,
+		Kind:    Kind,
+	}
+	if got := r.GroupVersionKind(); got != want {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+}

--- a/pkg/apis/serving/v1alpha1/register.go
+++ b/pkg/apis/serving/v1alpha1/register.go
@@ -26,6 +26,17 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+const (
+	// The group name. This is used for CRDs.
+	GroupName = "serving.knative.dev"
+
+	// The Version of the schema. This is used for CRDs.
+	SchemaVersion = "v1alpha1"
+
+	// The Kind of the custom resource. This is used for CRDs.
+	Kind = "KnativeServing"
+)
+
 // Resource takes an unqualified resource and returns a Group qualified GroupResource
 func Resource(resource string) schema.GroupResource {
 	return SchemeGroupVersion.WithResource(resource).GroupResource()
@@ -43,7 +54,7 @@ func addKnownTypes(s *runtime.Scheme) error {
 
 var (
 	// SchemeGroupVersion is group version used to register these objects
-	SchemeGroupVersion = schema.GroupVersion{Group: "serving.knative.dev", Version: "v1alpha1"}
+	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: SchemaVersion}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)

--- a/pkg/apis/serving/v1alpha1/register_test.go
+++ b/pkg/apis/serving/v1alpha1/register_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package v1alpha1
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestRegisterHelpers(t *testing.T) {
+	if got, want := Resource("KnativeServing"), "KnativeServing."+GroupName; got.String() != want {
+		t.Errorf("Resource(PodAutoscaler) = %v, want %v", got.String(), want)
+	}
+
+	if got, want := SchemeGroupVersion.String(), GroupName+"/v1alpha1"; got != want {
+		t.Errorf("SchemeGroupVersion() = %v, want %v", got, want)
+	}
+
+	scheme := runtime.NewScheme()
+	if err := addKnownTypes(scheme); err != nil {
+		t.Errorf("addKnownTypes() = %v", err)
+	}
+}

--- a/pkg/reconciler/knativeserving/knativeserving_controller.go
+++ b/pkg/reconciler/knativeserving/knativeserving_controller.go
@@ -111,8 +111,6 @@ func (r *Reconciler) reconcile(ctx context.Context, ks *servingv1alpha1.KnativeS
 	reqLogger := r.Logger.With(zap.String("Request.Namespace", ks.Namespace)).With("Request.Name", ks.Name)
 	reqLogger.Infow("Reconciling KnativeServing", "status", ks.Status)
 
-	// TODO: We need to find a better way to make sure the instance has the updated info.
-	ks.SetGroupVersionKind(servingv1alpha1.SchemeGroupVersion.WithKind("KnativeServing"))
 	stages := []func(*mf.Manifest, *servingv1alpha1.KnativeServing) error{
 		r.initStatus,
 		r.install,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes
* The CR KnativeServing can have a default GroupVersionKind, so that we do not need to set it in the reconcile function.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
