### PR TITLE
Skip the namespace check for integration test

### DIFF
--- a/test/e2e/knativeservingdeployment_test.go
+++ b/test/e2e/knativeservingdeployment_test.go
@@ -224,6 +224,11 @@ func knativeServingDelete(t *testing.T, clients *test.Clients, names test.Resour
 		t.Fatal(err)
 	}
 	for _, u := range m.Resources {
+		if u.GetKind() == "Namespace" {
+			// The namespace should be skipped, because when the CR is removed, the Manifest to be removed has
+			// been modified, since the namespace can be injected.
+			continue
+		}
 		waitErr := wait.PollImmediate(resources.Interval, resources.Timeout, func() (bool, error) {
 			gvrs, _ := meta.UnsafeGuessKindToResource(u.GroupVersionKind())
 			if _, err := clients.Dynamic.Resource(gvrs).Get(u.GetName(), metav1.GetOptions{}); apierrs.IsNotFound(err) {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


## Proposed Changes

* This PR skips the namespace check, because the namespace in the Manifest can be overwritten by injected namespace. When the CR is deleted, the original namespace can still exist.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
