### PR TITLE
Removing logging override examples from config-logging.yaml

### DIFF
--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -58,13 +58,3 @@ data:
           "callerEncoder": ""
         }
       }
-
-    # Log level overrides
-    # For all components except the autoscaler and queue proxy,
-    # changes are be picked up immediately.
-    # For autoscaler and queue proxy, changes require recreation of the pods.
-    loglevel.controller: "info"
-    loglevel.autoscaler: "info"
-    loglevel.queueproxy: "info"
-    loglevel.webhook: "info"
-    loglevel.activator: "info"


### PR DESCRIPTION
I believe this file was copied from knative-serving and these
examples could give the impression that the knative-serving logging
configuration can be changed from the operator's config-logging,
which isn't the case.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Remove logging configuration examples which could be confusing/misleading

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
