### PR TITLE
Add a new script to test the latest generated manifest of knative serving

### DIFF
--- a/test/config
+++ b/test/config
@@ -1,0 +1,1 @@
+../cmd/manager/kodata/knative-serving

--- a/test/config/0.8.0.yaml
+++ b/test/config/0.8.0.yaml
@@ -1,1 +1,0 @@
-../../cmd/manager/kodata/knative-serving/0.8.0.yaml

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -86,11 +86,6 @@ function install_serving_operator() {
   wait_until_pods_running default || fail_test "Serving Operator did not come up"
 }
 
-function knative_setup() {
-  install_istio || fail_test "Istio installation failed"
-  install_serving_operator
-}
-
 # Uninstalls Knative Serving from the current cluster.
 function knative_teardown() {
   echo ">> Uninstalling Knative serving"

--- a/test/e2e-tests-latest-serving.sh
+++ b/test/e2e-tests-latest-serving.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script runs the end-to-end tests against Knative Serving
+# Operator built from source. However, this script will download the latest
+# source code of knative serving and generated the latest manifest file for
+# serving installation. The serving operator will use this newly generated
+# manifest file to replace the one under the directory
+# cmd/manager/kodata/knative-serving. This purpose of this script is to verify
+# whether the latest source code of operator can work properly with the latest
+# source code of knative serving.
+
+# If you already have a Knative cluster setup and kubectl pointing
+# to it, call this script with the --run-tests arguments and it will use
+# the cluster and run the tests.
+
+# Calling this script without arguments will create a new cluster in
+# project $PROJECT_ID, start knative in it, run the tests and delete the
+# cluster.
+
+source $(dirname $0)/e2e-common.sh
+
+OPERATOR_DIR=$(dirname $0)/..
+KNATIVE_SERVING_DIR=$OPERATOR_DIR/..
+
+function knative_setup() {
+  install_istio || fail_test "Istio installation failed"
+  generate_latest_serving_manifest
+  install_serving_operator
+}
+
+function generate_latest_serving_manifest() {
+  # Go the directory to download the source code of knative serving
+  cd $KNATIVE_SERVING_DIR
+
+  # Download the source code of knative serving
+  git clone https://github.com/knative/serving.git
+  cd serving
+  mkdir -p output
+
+  # Generate the manifest
+  export YAML_OUTPUT_DIR=$KNATIVE_SERVING_DIR/serving/output
+  ./hack/generate-yamls.sh $KNATIVE_SERVING_DIR/serving $YAML_OUTPUT_DIR/output.yaml
+
+  # Copy the serving.yaml into cmd/manager/kodata/knative-serving
+  SERVING_YAML=$KNATIVE_SERVING_DIR/serving/output/serving.yaml
+  if [[ -f "$SERVING_YAML" ]]; then
+    echo ">> Replacing the current manifest in operator with the generated manifest"
+    rm -rf $OPERATOR_DIR/cmd/manager/kodata/knative-serving/*
+    cp $SERVING_YAML $OPERATOR_DIR/cmd/manager/kodata/knative-serving/serving.yaml
+  else
+    echo ">> The serving.yaml was not generated, so keep the current manifest"
+  fi
+
+  # Go back to the directory of operator
+  cd $OPERATOR_DIR
+}
+
+# Skip installing istio as an add-on
+initialize $@ --skip-istio-addon
+
+# If we got this far, the operator installed Knative Serving of the latest source code.
+header "Running tests for Knative Serving Operator"
+failed=0
+
+# Run the integration tests
+go_test_e2e -timeout=20m ./test/e2e || failed=1
+
+# Require that tests succeeded.
+(( failed )) && fail_test
+
+success

--- a/test/e2e-tests-latest-serving.sh
+++ b/test/e2e-tests-latest-serving.sh
@@ -34,7 +34,7 @@
 source $(dirname $0)/e2e-common.sh
 
 OPERATOR_DIR=$(dirname $0)/..
-KNATIVE_SERVING_DIR=$OPERATOR_DIR/..
+KNATIVE_SERVING_DIR=${OPERATOR_DIR}/..
 
 function knative_setup() {
   install_istio || fail_test "Istio installation failed"
@@ -44,7 +44,7 @@ function knative_setup() {
 
 function generate_latest_serving_manifest() {
   # Go the directory to download the source code of knative serving
-  cd $KNATIVE_SERVING_DIR
+  cd ${KNATIVE_SERVING_DIR}
 
   # Download the source code of knative serving
   git clone https://github.com/knative/serving.git
@@ -52,21 +52,21 @@ function generate_latest_serving_manifest() {
   mkdir -p output
 
   # Generate the manifest
-  export YAML_OUTPUT_DIR=$KNATIVE_SERVING_DIR/serving/output
-  ./hack/generate-yamls.sh $KNATIVE_SERVING_DIR/serving $YAML_OUTPUT_DIR/output.yaml
+  export YAML_OUTPUT_DIR=${KNATIVE_SERVING_DIR}/serving/output
+  ./hack/generate-yamls.sh ${KNATIVE_SERVING_DIR}/serving ${YAML_OUTPUT_DIR}/output.yaml
 
   # Copy the serving.yaml into cmd/manager/kodata/knative-serving
-  SERVING_YAML=$KNATIVE_SERVING_DIR/serving/output/serving.yaml
-  if [[ -f "$SERVING_YAML" ]]; then
+  SERVING_YAML=${KNATIVE_SERVING_DIR}/serving/output/serving.yaml
+  if [[ -f "${SERVING_YAML}" ]]; then
     echo ">> Replacing the current manifest in operator with the generated manifest"
-    rm -rf $OPERATOR_DIR/cmd/manager/kodata/knative-serving/*
-    cp $SERVING_YAML $OPERATOR_DIR/cmd/manager/kodata/knative-serving/serving.yaml
+    rm -rf ${OPERATOR_DIR}/cmd/manager/kodata/knative-serving/*
+    cp ${SERVING_YAML} ${OPERATOR_DIR}/cmd/manager/kodata/knative-serving/serving.yaml
   else
     echo ">> The serving.yaml was not generated, so keep the current manifest"
   fi
 
   # Go back to the directory of operator
-  cd $OPERATOR_DIR
+  cd ${OPERATOR_DIR}
 }
 
 # Skip installing istio as an add-on

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -28,14 +28,13 @@
 
 source $(dirname $0)/e2e-common.sh
 
-# Script entry point.
+function knative_setup() {
+  install_istio || fail_test "Istio installation failed"
+  install_serving_operator
+}
 
 # Skip installing istio as an add-on
 initialize $@ --skip-istio-addon
-
-# Let's see what the operator did
-#kubectl get pod --all-namespaces
-#kubectl logs deployment/knative-serving-operator
 
 # If we got this far, the operator installed Knative Serving
 header "Running tests for Knative Serving Operator"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #188 

## Proposed Changes

* Added a new script called e2e-tests-latest-serving.sh, to run the operator installation with the latest generated manifest of knative serving, and run the integration tests against the Kube cluster. This script will be called directly by a periodic prow job.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
