### PR TITLE
Update vendor/knative.dev/test-infra

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1237,14 +1237,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:5299d75a2b08a91c54ffb8b76afe21eb5f1ecf7bc4d67b859fc081f9415452bc"
+  digest = "1:e4a2fd481bd2d6dcac5ae03c55d6104a0953d0a78cb45fdd4d20a116ed2a5218"
   name = "knative.dev/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "6c8da588aaa3d2bff76a9c37fd6ac5c9a6c02c09"
+  revision = "e381f11dc722330fe082158e2f22cd39f8fe8375"
 
 [[projects]]
   digest = "1:8730e0150dfb2b7e173890c8b9868e7a273082ef8e39f4940e3506a481cf895c"

--- a/vendor/knative.dev/test-infra/scripts/e2e-tests.sh
+++ b/vendor/knative.dev/test-infra/scripts/e2e-tests.sh
@@ -310,7 +310,7 @@ function create_test_cluster_with_retries() {
       # - latest GKE not available in this region/zone yet (https://github.com/knative/test-infra/issues/694)
       [[ -z "$(grep -Fo 'does not have enough resources available to fulfill' ${cluster_creation_log})" \
           && -z "$(grep -Fo 'ResponseError: code=400, message=No valid versions with the prefix' ${cluster_creation_log})" \
-          && -z "$(grep -Po 'ResponseError: code=400, message=Master version "[0-9a-z\-\.]+" is unsupported' ${cluster_creation_log})" ]] \
+          && -z "$(grep -Po 'ResponseError: code=400, message=Master version "[0-9a-z\-\.]+" is unsupported' ${cluster_creation_log})"  \
           && -z "$(grep -Po 'only \d+ nodes out of \d+ have registered; this is likely due to Nodes failing to start correctly' ${cluster_creation_log})" ]] \
           && return 1
     done
@@ -324,6 +324,9 @@ function setup_test_cluster() {
   # Fail fast during setup.
   set -o errexit
   set -o pipefail
+
+  header "Test cluster setup"
+  kubectl get nodes
 
   header "Setting up test cluster"
 

--- a/vendor/knative.dev/test-infra/scripts/performance-tests.sh
+++ b/vendor/knative.dev/test-infra/scripts/performance-tests.sh
@@ -106,12 +106,18 @@ function update_clusters() {
   header "Done updating all clusters"
 }
 
+# Run the perf-tests tool
+# Parameters: $1..$n - parameters passed to the tool
+function run_perf_cluster_tool() {
+  go run ${REPO_ROOT_DIR}/vendor/knative.dev/pkg/testutils/clustermanager/perf-tests $@
+}
+
 # Delete the old clusters belonged to the current repo, and recreate them with the same configuration.
 function recreate_clusters() {
   header "Recreating clusters for ${REPO_NAME}"
-  go run ${REPO_ROOT_DIR}/vendor/knative.dev/pkg/testutils/clustermanager/perf-tests \
-    --recreate \
-    --gcp-project=${PROJECT_NAME} --repository=${REPO_NAME} --benchmark-root=${BENCHMARK_ROOT_PATH}
+  run_perf_cluster_tool --recreate \
+    --gcp-project=${PROJECT_NAME} --repository=${REPO_NAME} --benchmark-root=${BENCHMARK_ROOT_PATH} \
+    || abort "failed recreating clusters for ${REPO_NAME}"
   header "Done recreating clusters"
   # Update all clusters after they are recreated
   update_clusters
@@ -121,9 +127,9 @@ function recreate_clusters() {
 # This function will be run as postsubmit jobs.
 function reconcile_benchmark_clusters() {
   header "Reconciling clusters for ${REPO_NAME}"
-  go run ${REPO_ROOT_DIR}/vendor/knative.dev/pkg/testutils/clustermanager/perf-tests \
-    --reconcile \
-    --gcp-project=${PROJECT_NAME} --repository=${REPO_NAME} --benchmark-root=${BENCHMARK_ROOT_PATH}
+  run_perf_cluster_tool --reconcile \
+    --gcp-project=${PROJECT_NAME} --repository=${REPO_NAME} --benchmark-root=${BENCHMARK_ROOT_PATH} \
+    || abort "failed reconciling clusters for ${REPO_NAME}"
   header "Done reconciling clusters"
   # For now, do nothing after reconciling the clusters, and the next update_clusters job will automatically 
   # update them. So there will be a period that the newly created clusters are being idle, and the duration

--- a/vendor/knative.dev/test-infra/scripts/release.sh
+++ b/vendor/knative.dev/test-infra/scripts/release.sh
@@ -212,7 +212,7 @@ function prepare_dot_release() {
     echo "Dot release will be generated for ${version_filter}"
     releases="$(echo "${releases}" | grep ^${version_filter})"
   fi
-  local last_version="$(echo "${releases}" | grep '^v[0-9]\+\.[0-9]\+\.[0-9]\+$' | sort -r | head -1)"
+  local last_version="$(echo "${releases}" | grep '^v[0-9]\+\.[0-9]\+\.[0-9]\+$' | sort -r -V | head -1)"
   [[ -n "${last_version}" ]] || abort "no previous release exist"
   local major_minor_version=""
   if [[ -z "${RELEASE_BRANCH}" ]]; then


### PR DESCRIPTION
Major changes:
* display E2E cluster setup during tests
* dump failed pod status when waiting for pods to come up during test setup
* fix detection of retriable failures during test cluster creation
* fix parsing error for autogenerated code in flaky test reporter
* fix automatic dot releases for 0.10+ branches

Part of https://github.com/knative/test-infra/issues/1542

/cc @grantr 
/cc @mattmoor 