### PR TITLE
Letting flags be changed from outside 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Temporary Build Files
 build/_output
 build/_test
+# Goland
+.idea
+
 # Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 ### Emacs ###
 # -*- mode: gitignore; -*-

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -20,13 +20,13 @@ set -o pipefail
 
 source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/library.sh
 
-cd ${REPO_ROOT_DIR}
+cd "${REPO_ROOT_DIR}"
 
 # Ensure we have everything we need under vendor/
 dep ensure
 
-rm -rf $(find vendor/ -name 'OWNERS')
-rm -rf $(find vendor/ -name '*_test.go')
+find vendor/ -name 'OWNERS' -delete
+find vendor/ -name '*_test.go' -delete
 
 update_licenses third_party/VENDOR-LICENSE "./cmd/*"
 

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -19,9 +19,19 @@ limitations under the License.
 
 package test
 
-const (
+import "os"
+
+var (
 	// ServingOperatorNamespace is the default namespace for serving operator e2e tests
-	ServingOperatorNamespace = "operator-tests"
+	ServingOperatorNamespace = getenv("TEST_NAMESPACE", "operator-tests")
 	// ServingOperatorName is the default operator name for serving operator e2e tests
-	ServingOperatorName = "knative-serving"
+	ServingOperatorName = getenv("TEST_RESOURCE", "knative-serving")
 )
+
+func getenv(name, defaultValue string) string {
+	value, set := os.LookupEnv(name)
+	if !set {
+		value = defaultValue
+	}
+	return value
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:
/lint
-->

## Proposed Changes

* *Letting flags be changed from outside*
  Changing those flags is needed to perform tests on RH operators.
* *Adding Intellij, and vandors excluded files to gitignore*

### Implementation

This PR let change test flags from outside. It can be done either by:

 * declaring environmental variables: `TEST_NAMESPACE`, and `TEST_RESOURCE`,
 * using `-ldflags "-X knative.dev/serving-operator/test.ServingOperatorNamespace=knative-serving"`

**Release Note**

```release-note
NONE
```