### PR TITLE
Add metrics about KnativeServing CR edits

### DIFF
--- a/pkg/reconciler/knativeserving/controller.go
+++ b/pkg/reconciler/knativeserving/controller.go
@@ -22,7 +22,6 @@ import (
 	"github.com/go-logr/zapr"
 	mf "github.com/jcrossley3/manifestival"
 	"go.uber.org/zap"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	deploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
@@ -56,7 +55,7 @@ func NewController(
 	c := &Reconciler{
 		Base:                 rbase.NewBase(ctx, controllerAgentName, cmw),
 		knativeServingLister: knativeServingInformer.Lister(),
-		servings:             sets.String{},
+		servings:             map[string]int64{},
 	}
 
 	koDataDir := os.Getenv("KO_DATA_PATH")

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -104,7 +104,6 @@ func NewBase(ctx context.Context, controllerAgentName string, cmw configmap.Watc
 	}
 
 	// Create metrics reporter
-	logger.Debug("Creating stats reporter")
 	statsReporter, err := NewStatsReporter(controllerAgentName)
 	if err != nil {
 		logger.Fatal(err)

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -62,6 +62,9 @@ type Base struct {
 	// Kubernetes API.
 	Recorder record.EventRecorder
 
+	// StatsReporter reports reconciler's metrics.
+	StatsReporter StatsReporter
+
 	// Sugared logger is easier to use but is not as performant as the
 	// raw logger. In performance critical paths, call logger.Desugar()
 	// and use the returned raw logger instead. In addition to the
@@ -100,6 +103,13 @@ func NewBase(ctx context.Context, controllerAgentName string, cmw configmap.Watc
 		}()
 	}
 
+	// Create metrics reporter
+	logger.Debug("Creating stats reporter")
+	statsReporter, err := NewStatsReporter(controllerAgentName)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
 	base := &Base{
 		KubeClientSet:           kubeClient,
 		SharedClientSet:         sharedclient.Get(ctx),
@@ -107,6 +117,7 @@ func NewBase(ctx context.Context, controllerAgentName string, cmw configmap.Watc
 		DynamicClientSet:        dynamicclient.Get(ctx),
 		ConfigMapWatcher:        cmw,
 		Recorder:                recorder,
+		StatsReporter:           statsReporter,
 		Logger:                  logger,
 	}
 

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -49,4 +49,7 @@ func TestNewBase(t *testing.T) {
 	if r.Recorder == nil {
 		t.Fatal("Expected NewBase to add a Recorder")
 	}
+	if r.StatsReporter == nil {
+		t.Fatal("Expected NewBase to add a StatsReporter")
+	}
 }

--- a/pkg/reconciler/stats_reporter.go
+++ b/pkg/reconciler/stats_reporter.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"context"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+	"knative.dev/pkg/metrics"
+)
+
+const (
+	knativeServingChangeCountName = "knativeserving_change_count"
+)
+
+var (
+	knativeServingChangeCountStat = stats.Int64(
+		knativeServingChangeCountName,
+		"Number of KnativeServing changes including creation, edit and deletion",
+		stats.UnitDimensionless)
+	// Create the tag keys that will be used to add tags to our measurements.
+	// Tag keys must conform to the restrictions described in
+	// go.opencensus.io/tag/validate.go. Currently those restrictions are:
+	// - length between 1 and 255 inclusive
+	// - characters are printable US-ASCII
+	reconcilerTagKey     = tag.MustNewKey("reconciler")
+	knativeServingTagKey = tag.MustNewKey("knativeServing")
+	changeTagKey         = tag.MustNewKey("change")
+)
+
+func init() {
+	// Create views to see our measurements. This can return an error if
+	// a previously-registered view has the same name with a different value.
+	// View name defaults to the measure name if unspecified.
+	views := []*view.View{{
+		Description: knativeServingChangeCountStat.Description(),
+		Measure:     knativeServingChangeCountStat,
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{reconcilerTagKey, knativeServingTagKey, changeTagKey},
+	}}
+
+	if err := view.Register(views...); err != nil {
+		panic(err)
+	}
+}
+
+// StatsReporter defines the interface for sending metrics.
+type StatsReporter interface {
+	// ReportKnativeServingChange reports the count of KnativeServing CR changes.
+	ReportKnativeServingChange(knativeServing, change string) error
+}
+
+// reporter holds cached metric objects to report metrics.
+type reporter struct {
+	reconcilerName string
+	ctx            context.Context
+}
+
+// NewStatsReporter creates a reporter that collects and reports metrics.
+func NewStatsReporter(reconcilerName string) (StatsReporter, error) {
+	// Reconciler tag is static. Create a context containing that and cache it.
+	ctx, err := tag.New(
+		context.Background(),
+		tag.Insert(reconcilerTagKey, reconcilerName))
+	if err != nil {
+		return nil, err
+	}
+	return &reporter{reconcilerName: reconcilerName, ctx: ctx}, nil
+}
+
+// ReportKnativeServingChange reports the count of KnativeServing CR changes
+// including creation, edit and deletion.
+func (r *reporter) ReportKnativeServingChange(knativeServing, change string) error {
+	ctx, err := tag.New(
+		r.ctx,
+		tag.Insert(knativeServingTagKey, knativeServing),
+		tag.Insert(changeTagKey, change))
+	if err != nil {
+		return err
+	}
+
+	metrics.Record(ctx, knativeServingChangeCountStat.M(1))
+	return nil
+}

--- a/pkg/reconciler/stats_reporter.go
+++ b/pkg/reconciler/stats_reporter.go
@@ -26,22 +26,22 @@ import (
 )
 
 const (
-	knativeServingChangeCountName = "knativeserving_change_count"
+	knativeservingChangeCountName = "knativeserving_change_count"
 )
 
 var (
-	knativeServingChangeCountStat = stats.Int64(
-		knativeServingChangeCountName,
-		"Number of KnativeServing changes including creation, edit and deletion",
+	knativeservingChangeCountStat = stats.Int64(
+		knativeservingChangeCountName,
+		"Number of changes to the KnativeServing Custom Resource where a change can be creation, edit, or deletion",
 		stats.UnitDimensionless)
 	// Create the tag keys that will be used to add tags to our measurements.
 	// Tag keys must conform to the restrictions described in
 	// go.opencensus.io/tag/validate.go. Currently those restrictions are:
 	// - length between 1 and 255 inclusive
 	// - characters are printable US-ASCII
-	reconcilerTagKey     = tag.MustNewKey("reconciler")
-	knativeServingTagKey = tag.MustNewKey("knativeServing")
-	changeTagKey         = tag.MustNewKey("change")
+	reconcilerNameTagKey             = tag.MustNewKey("reconciler_name")
+	knativeservingResourceNameTagKey = tag.MustNewKey("knativeserving_resource_name")
+	changeTagKey                     = tag.MustNewKey("change")
 )
 
 func init() {
@@ -49,10 +49,10 @@ func init() {
 	// a previously-registered view has the same name with a different value.
 	// View name defaults to the measure name if unspecified.
 	views := []*view.View{{
-		Description: knativeServingChangeCountStat.Description(),
-		Measure:     knativeServingChangeCountStat,
+		Description: knativeservingChangeCountStat.Description(),
+		Measure:     knativeservingChangeCountStat,
 		Aggregation: view.Count(),
-		TagKeys:     []tag.Key{reconcilerTagKey, knativeServingTagKey, changeTagKey},
+		TagKeys:     []tag.Key{reconcilerNameTagKey, knativeservingResourceNameTagKey, changeTagKey},
 	}}
 
 	if err := view.Register(views...); err != nil {
@@ -62,8 +62,8 @@ func init() {
 
 // StatsReporter defines the interface for sending metrics.
 type StatsReporter interface {
-	// ReportKnativeServingChange reports the count of KnativeServing CR changes.
-	ReportKnativeServingChange(knativeServing, change string) error
+	// ReportKnativeServingChange reports the count of KnativeServing changes.
+	ReportKnativeservingChange(knativeservingResourceName, change string) error
 }
 
 // reporter holds cached metric objects to report metrics.
@@ -77,24 +77,24 @@ func NewStatsReporter(reconcilerName string) (StatsReporter, error) {
 	// Reconciler tag is static. Create a context containing that and cache it.
 	ctx, err := tag.New(
 		context.Background(),
-		tag.Insert(reconcilerTagKey, reconcilerName))
+		tag.Insert(reconcilerNameTagKey, reconcilerName))
 	if err != nil {
 		return nil, err
 	}
 	return &reporter{reconcilerName: reconcilerName, ctx: ctx}, nil
 }
 
-// ReportKnativeServingChange reports the count of KnativeServing CR changes
-// including creation, edit and deletion.
-func (r *reporter) ReportKnativeServingChange(knativeServing, change string) error {
+// ReportKnativeServingChange reports the number of changes to the KnativeServing
+// Custom Resource where a change can be creation, edit, or deletion.
+func (r *reporter) ReportKnativeservingChange(knativeservingResourceName, change string) error {
 	ctx, err := tag.New(
 		r.ctx,
-		tag.Insert(knativeServingTagKey, knativeServing),
+		tag.Insert(knativeservingResourceNameTagKey, knativeservingResourceName),
 		tag.Insert(changeTagKey, change))
 	if err != nil {
 		return err
 	}
 
-	metrics.Record(ctx, knativeServingChangeCountStat.M(1))
+	metrics.Record(ctx, knativeservingChangeCountStat.M(1))
 	return nil
 }

--- a/pkg/reconciler/stats_reporter_test.go
+++ b/pkg/reconciler/stats_reporter_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"testing"
+
+	"go.opencensus.io/tag"
+	"go.opencensus.io/stats/view"
+	"knative.dev/pkg/metrics/metricstest"
+)
+
+const (
+	reconcilerMockName = "mock_reconciler"
+	testKey            = "test/key"
+)
+
+func TestNewStatsReporter(t *testing.T) {
+	r, err := NewStatsReporter(reconcilerMockName)
+	if err != nil {
+		t.Errorf("Failed to create reporter: %v", err)
+	}
+
+	m := tag.FromContext(r.(*reporter).ctx)
+	v, ok := m.Value(reconcilerTagKey)
+	if !ok {
+		t.Fatalf("Expected tag %q", reconcilerTagKey)
+	}
+	if v != reconcilerMockName {
+		t.Fatalf("Expected %q for tag %q, got %q", reconcilerMockName, reconcilerTagKey, v)
+	}
+}
+
+func TestReportKnativeServingChange(t *testing.T) {
+	r, _ := NewStatsReporter(reconcilerMockName)
+	wantTags := map[string]string{
+		reconcilerTagKey.Name():     reconcilerMockName,
+		knativeServingTagKey.Name(): testKey,
+		changeTagKey.Name():         "creation",
+	}
+	countWas := int64(0)
+	if d, err := view.RetrieveData(knativeServingChangeCountName); err == nil && len(d) == 1 {
+		countWas = d[0].Data.(*view.CountData).Value
+	}
+
+	if err := r.ReportKnativeServingChange(testKey, "creation"); err != nil {
+		t.Error(err)
+	}
+
+	metricstest.CheckCountData(t, knativeServingChangeCountName, wantTags, countWas+1)
+}

--- a/pkg/reconciler/stats_reporter_test.go
+++ b/pkg/reconciler/stats_reporter_test.go
@@ -19,47 +19,47 @@ package reconciler
 import (
 	"testing"
 
-	"go.opencensus.io/tag"
 	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
 	"knative.dev/pkg/metrics/metricstest"
 )
 
 const (
-	reconcilerMockName = "mock_reconciler"
-	testKey            = "test/key"
+	testReconcilerName             = "test_reconciler"
+	testKnativeservingResourceName = "ns/name"
 )
 
 func TestNewStatsReporter(t *testing.T) {
-	r, err := NewStatsReporter(reconcilerMockName)
+	r, err := NewStatsReporter(testReconcilerName)
 	if err != nil {
 		t.Errorf("Failed to create reporter: %v", err)
 	}
 
 	m := tag.FromContext(r.(*reporter).ctx)
-	v, ok := m.Value(reconcilerTagKey)
+	v, ok := m.Value(reconcilerNameTagKey)
 	if !ok {
-		t.Fatalf("Expected tag %q", reconcilerTagKey)
+		t.Fatalf("Expected tag %q", reconcilerNameTagKey)
 	}
-	if v != reconcilerMockName {
-		t.Fatalf("Expected %q for tag %q, got %q", reconcilerMockName, reconcilerTagKey, v)
+	if v != testReconcilerName {
+		t.Fatalf("Expected %q for tag %q, got %q", testReconcilerName, reconcilerNameTagKey, v)
 	}
 }
 
 func TestReportKnativeServingChange(t *testing.T) {
-	r, _ := NewStatsReporter(reconcilerMockName)
+	r, _ := NewStatsReporter(testReconcilerName)
 	wantTags := map[string]string{
-		reconcilerTagKey.Name():     reconcilerMockName,
-		knativeServingTagKey.Name(): testKey,
-		changeTagKey.Name():         "creation",
+		reconcilerNameTagKey.Name():             testReconcilerName,
+		knativeservingResourceNameTagKey.Name(): testKnativeservingResourceName,
+		changeTagKey.Name():                     "creation",
 	}
 	countWas := int64(0)
-	if d, err := view.RetrieveData(knativeServingChangeCountName); err == nil && len(d) == 1 {
+	if d, err := view.RetrieveData(knativeservingChangeCountName); err == nil && len(d) == 1 {
 		countWas = d[0].Data.(*view.CountData).Value
 	}
 
-	if err := r.ReportKnativeServingChange(testKey, "creation"); err != nil {
+	if err := r.ReportKnativeservingChange(testKnativeservingResourceName, "creation"); err != nil {
 		t.Error(err)
 	}
 
-	metricstest.CheckCountData(t, knativeServingChangeCountName, wantTags, countWas+1)
+	metricstest.CheckCountData(t, knativeservingChangeCountName, wantTags, countWas+1)
 }


### PR DESCRIPTION
## Proposed Changes

Serving operator can emit metrics on KnativeServing CR edits, including creation, modification and deletion.

Steps to test metrics with Prometheus exporter (default):

1. Forward the local port 9090 to the port 9090 on operator pod by running
`kubectl port-forward ${{operator_pod_name}} 9090`
2. Check the metrics by visiting `localhost:9090/metrics`

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
