### PR TITLE
Add a "DependenciesInstalled" condition that defaults to true

### DIFF
--- a/pkg/apis/serving/v1alpha1/knativeserving_lifecycle_test.go
+++ b/pkg/apis/serving/v1alpha1/knativeserving_lifecycle_test.go
@@ -32,3 +32,22 @@ func TestKnativeServingGroupVersionKind(t *testing.T) {
 		t.Errorf("got: %v, want: %v", got, want)
 	}
 }
+
+func TestAssumeDepsInstalled(t *testing.T) {
+	ks := &KnativeServingStatus{}
+	ks.InitializeConditions()
+	assertEqual(t, ks.GetCondition(DependenciesInstalled).IsUnknown(), true)
+	assertEqual(t, ks.GetCondition(DependenciesInstalled).IsTrue(), false)
+	ks.MarkInstallSucceeded()
+	assertEqual(t, ks.GetCondition(DependenciesInstalled).IsUnknown(), false)
+	assertEqual(t, ks.GetCondition(DependenciesInstalled).IsTrue(), true)
+	assertEqual(t, ks.IsInstalled(), true)
+	assertEqual(t, ks.IsFullySupported(), true)
+}
+
+func assertEqual(t *testing.T, actual, expected interface{}) {
+	if actual == expected {
+		return
+	}
+	t.Fatalf("Expected: %v\nActual: %v", expected, actual)
+}

--- a/pkg/apis/serving/v1alpha1/knativeserving_types.go
+++ b/pkg/apis/serving/v1alpha1/knativeserving_types.go
@@ -25,8 +25,9 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 const (
-	InstallSucceeded     apis.ConditionType = "InstallSucceeded"
-	DeploymentsAvailable apis.ConditionType = "DeploymentsAvailable"
+	DependenciesInstalled apis.ConditionType = "DependenciesInstalled"
+	InstallSucceeded      apis.ConditionType = "InstallSucceeded"
+	DeploymentsAvailable  apis.ConditionType = "DeploymentsAvailable"
 )
 
 // Registry defines image overrides of knative images.


### PR DESCRIPTION
This allows any other controllers, e.g. platform-specific ones, watching the KnativeServing resource to defer its "Ready" condition until any deps on that platform, e.g. a service mesh, are successfully installed.

This is effectively a no-op unless some other controller marks the condition as "missing" or "installing".
