### PR TITLE
Feature: reuse e2e tests on productized code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Temporary Build Files
 build/_output
 build/_test
+# Goland
+.idea
+
 # Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 ### Emacs ###
 # -*- mode: gitignore; -*-

--- a/cmd/manager/kodata/knative-serving/dummy.go
+++ b/cmd/manager/kodata/knative-serving/dummy.go
@@ -1,11 +1,12 @@
-// +build e2e
-
 /*
 Copyright 2019 The Knative Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,13 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
-
-import (
-	"testing"
-)
-
-// TestKnativeServingDeployment verifies the KnativeServing creation, deployment recreation, and KnativeServing deletion.
-func TestKnativeServingDeployment(t *testing.T) {
-	testKnativeServingDeployment(t)
-}
+// Package knative_serving is a dummy buildable source file to satisfy `dep`
+package knative_serving

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -20,13 +20,13 @@ set -o pipefail
 
 source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/library.sh
 
-cd ${REPO_ROOT_DIR}
+cd "${REPO_ROOT_DIR}"
 
 # Ensure we have everything we need under vendor/
 dep ensure
 
-rm -rf $(find vendor/ -name 'OWNERS')
-rm -rf $(find vendor/ -name '*_test.go')
+find vendor/ -name 'OWNERS' -delete
+find vendor/ -name '*_test.go' -delete
 
 update_licenses third_party/VENDOR-LICENSE "./cmd/*"
 

--- a/test/context.go
+++ b/test/context.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2019 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import "testing"
+
+// Context represents a testing context that can be tuned to override specific
+// parts of a suite
+type Context struct {
+	t           *testing.T
+	overrides   []Specification
+	activeTests []string
+}
+
+// T returns standard testing.T
+func (ctx Context) T() *testing.T {
+	return ctx.t
+}
+
+// Runner creates a new runner based on a given context
+func (ctx Context) Runner() Runner {
+	return contextRunner{
+		ctx: &ctx,
+	}
+}
+
+// RunSuite executes given test or execute it's override
+func (runner contextRunner) Run(name string, testfunc func(t *testing.T)) bool {
+	ctx := runner.ctx
+	t := ctx.t
+	for _, spec := range ctx.overrides {
+		if spec.matchesNameInContext(name, ctx) {
+			t.Logf("Overriding %s test", spec.name())
+			return t.Run(name, spec.testfunc(ctx))
+		}
+	}
+	return t.Run(name, testfunc)
+}
+
+// WithOverride adds specification to be executed instead of given test
+func (ctx *Context) WithOverride(spec Specification) *Context {
+	ctx.overrides = append(ctx.overrides, spec)
+	return ctx
+}
+
+// RunSuite will run a test suite within given context
+func (ctx *Context) RunSuite(suite []Specification) {
+	for _, spec := range suite {
+		spec.run(ctx)
+	}
+}
+
+// NewContext creates a new context
+func NewContext(t *testing.T) *Context {
+	return &Context{
+		t:           t,
+		overrides:   make([]Specification, 0),
+		activeTests: make([]string, 0),
+	}
+}
+
+func (ctx *Context) push(testname string) {
+	ctx.activeTests = append(ctx.activeTests, testname)
+}
+
+func (ctx *Context) pop() string {
+	// Top element
+	n := len(ctx.activeTests) - 1
+	testname := ctx.activeTests[n]
+	ctx.activeTests = ctx.activeTests[:n]
+	return testname
+}
+
+type contextRunner struct {
+	ctx *Context
+}

--- a/test/e2e/compliance.go
+++ b/test/e2e/compliance.go
@@ -1,5 +1,3 @@
-// +build e2e
-
 /*
 Copyright 2019 The Knative Authors
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,11 +13,14 @@ limitations under the License.
 
 package e2e
 
-import (
-	"testing"
-)
+import "knative.dev/serving-operator/test"
 
-// TestKnativeServingDeployment verifies the KnativeServing creation, deployment recreation, and KnativeServing deletion.
-func TestKnativeServingDeployment(t *testing.T) {
-	testKnativeServingDeployment(t)
+// ComplianceSuite can be executed by productized code's test plan to assert
+// compliance with upstream knative
+func ComplianceSuite() []test.Specification {
+	return specifications
+}
+
+var specifications = []test.Specification{
+	test.NewSpec("TestKnativeServingDeployment", testKnativeServingDeployment),
 }

--- a/test/e2e/compliance.go
+++ b/test/e2e/compliance.go
@@ -18,9 +18,9 @@ import "knative.dev/serving-operator/test"
 // ComplianceSuite can be executed by productized code's test plan to assert
 // compliance with upstream knative
 func ComplianceSuite() []test.Specification {
-	return specifications
+	return suite
 }
 
-var specifications = []test.Specification{
-	test.NewSpec("TestKnativeServingDeployment", testKnativeServingDeployment),
+var suite = []test.Specification{
+	test.NewContextualSpec("TestKnativeServingDeployment", testKnativeServingDeployment),
 }

--- a/test/e2e/compliance_test.go
+++ b/test/e2e/compliance_test.go
@@ -1,5 +1,3 @@
-// +build e2e
-
 /*
 Copyright 2019 The Knative Authors
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,11 +13,12 @@ limitations under the License.
 
 package e2e
 
-import (
-	"testing"
-)
+import "testing"
 
-// TestKnativeServingDeployment verifies the KnativeServing creation, deployment recreation, and KnativeServing deletion.
-func TestKnativeServingDeployment(t *testing.T) {
-	testKnativeServingDeployment(t)
+func TestComplianceSuite(t *testing.T) {
+	suite := ComplianceSuite()
+
+	if len(suite) <= 0 {
+		t.Error("There should be some tests that are exported as compliance suite")
+	}
 }

--- a/test/e2e/compliance_test.go
+++ b/test/e2e/compliance_test.go
@@ -13,7 +13,10 @@ limitations under the License.
 
 package e2e
 
-import "testing"
+import (
+	"knative.dev/serving-operator/test"
+	"testing"
+)
 
 func TestComplianceSuite(t *testing.T) {
 	suite := ComplianceSuite()
@@ -21,4 +24,58 @@ func TestComplianceSuite(t *testing.T) {
 	if len(suite) <= 0 {
 		t.Error("There should be some tests that are exported as compliance suite")
 	}
+}
+
+var runState map[string]int
+
+const exampleJira = "XXXX-1234"
+
+func TestSkipOfSpecificPartOfTestSuite(t *testing.T) {
+	suite := exampleComplianceSuite()
+
+	runState = map[string]int{
+		"alpha": 0,
+		"beta":  0,
+		"gamma": 0,
+	}
+
+	test.
+		NewContext(t).
+		WithOverride(test.Skipf("TestParent/beta", "Skip due to %v", exampleJira)).
+		RunSuite(suite)
+
+	if runState["alpha"] != 1 {
+		t.Error("Alpha should be executed just once")
+	}
+	if runState["beta"] != 0 {
+		t.Error("Beta should be skipped, but wasn't")
+	}
+	if runState["gamma"] != 1 {
+		t.Error("Gamma should be executed just once")
+	}
+}
+
+func exampleComplianceSuite() []test.Specification {
+	return []test.Specification{
+		test.NewContextualSpec("TestParent", testParent),
+	}
+}
+
+func testParent(ctx *test.Context) {
+	r := ctx.Runner()
+
+	r.Run("alpha", func(t *testing.T) {
+		t.Log("Alpha is OK")
+		runState["alpha"]++
+	})
+
+	r.Run("beta", func(t *testing.T) {
+		runState["beta"]++
+		t.Errorf("Beta is failing, because %v", exampleJira)
+	})
+
+	r.Run("gamma", func(t *testing.T) {
+		t.Log("Gamma is OK")
+		runState["gamma"]++
+	})
 }

--- a/test/e2e/knativeservingdeployment.go
+++ b/test/e2e/knativeservingdeployment.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2019 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	mf "github.com/jcrossley3/manifestival"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/pkg/test/logstream"
+	"knative.dev/serving-operator/pkg/apis/serving/v1alpha1"
+	"knative.dev/serving-operator/test"
+	"knative.dev/serving-operator/test/resources"
+)
+
+func testKnativeServingDeployment(t *testing.T) {
+
+	cancel := logstream.Start(t)
+	defer cancel()
+	clients := Setup(t)
+
+	names := test.ResourceNames{
+		KnativeServing: test.ServingOperatorName,
+		Namespace:      test.ServingOperatorNamespace,
+	}
+
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
+
+	// Create a KnativeServing
+	if _, err := resources.CreateKnativeServing(clients.KnativeServing(), names); err != nil {
+		t.Fatalf("KnativeService %q failed to create: %v", names.KnativeServing, err)
+	}
+
+	// Test if KnativeServing can reach the READY status
+	t.Run("create", func(t *testing.T) {
+		knativeServingVerify(t, clients, names)
+	})
+
+	t.Run("configure", func(t *testing.T) {
+		knativeServingVerify(t, clients, names)
+		knativeServingConfigure(t, clients, names)
+	})
+
+	// Delete the deployments one by one to see if they will be recreated.
+	t.Run("restore", func(t *testing.T) {
+		knativeServingVerify(t, clients, names)
+		deploymentRecreation(t, clients, names)
+	})
+
+	// Delete the KnativeServing to see if all resources will be removed
+	t.Run("delete", func(t *testing.T) {
+		knativeServingVerify(t, clients, names)
+		knativeServingDelete(t, clients, names)
+	})
+}
+
+// knativeServingVerify verifies if the KnativeServing can reach the READY status.
+func knativeServingVerify(t *testing.T, clients *test.Clients, names test.ResourceNames) {
+	if _, err := resources.WaitForKnativeServingState(clients.KnativeServing(), names.KnativeServing,
+		resources.IsKnativeServingReady); err != nil {
+		t.Fatalf("KnativeService %q failed to get to the READY status: %v", names.KnativeServing, err)
+	}
+
+}
+
+// knativeServingConfigure verifies that KnativeServing config is set properly
+func knativeServingConfigure(t *testing.T, clients *test.Clients, names test.ResourceNames) {
+	// We'll arbitrarily choose logging and defaults config
+	loggingConfigKey := "logging"
+	loggingConfigMapName := fmt.Sprintf("%s/config-%s", names.Namespace, loggingConfigKey)
+	defaultsConfigKey := "defaults"
+	defaultsConfigMapName := fmt.Sprintf("%s/config-%s", names.Namespace, defaultsConfigKey)
+	// Get the existing KS without any spec
+	ks, err := clients.KnativeServing().Get(names.KnativeServing, metav1.GetOptions{})
+	// Add config to its spec
+	ks.Spec = v1alpha1.KnativeServingSpec{
+		Config: map[string]map[string]string{
+			defaultsConfigKey: {
+				"revision-timeout-seconds": "200",
+			},
+			loggingConfigKey: {
+				"loglevel.controller": "debug",
+				"loglevel.autoscaler": "debug",
+			},
+		},
+	}
+	// Update it
+	if ks, err = clients.KnativeServing().Update(ks); err != nil {
+		t.Fatalf("KnativeServing %q failed to update: %v", names.KnativeServing, err)
+	}
+	// Verify the relevant configmaps have been updated
+	err = resources.WaitForConfigMap(defaultsConfigMapName, clients.KubeClient.Kube, func(m map[string]string) bool {
+		return m["revision-timeout-seconds"] == "200"
+	})
+	if err != nil {
+		t.Fatalf("The operator failed to update %s configmap", defaultsConfigMapName)
+	}
+	err = resources.WaitForConfigMap(loggingConfigMapName, clients.KubeClient.Kube, func(m map[string]string) bool {
+		return m["loglevel.controller"] == "debug" && m["loglevel.autoscaler"] == "debug"
+	})
+	if err != nil {
+		t.Fatalf("The operator failed to update %s configmap", loggingConfigMapName)
+	}
+
+	// Delete a single key/value pair
+	delete(ks.Spec.Config[loggingConfigKey], "loglevel.autoscaler")
+	// Update it
+	if ks, err = clients.KnativeServing().Update(ks); err != nil {
+		t.Fatalf("KnativeServing %q failed to update: %v", names.KnativeServing, err)
+	}
+	// Verify the relevant configmap has been updated
+	err = resources.WaitForConfigMap(loggingConfigMapName, clients.KubeClient.Kube, func(m map[string]string) bool {
+		_, autoscalerKeyExists := m["loglevel.autoscaler"]
+		// deleted key/value pair should be removed from the target config map
+		return m["loglevel.controller"] == "debug" && !autoscalerKeyExists
+	})
+	if err != nil {
+		t.Fatal("The operator failed to update the configmap")
+	}
+
+	// Use an empty map as the value
+	ks.Spec.Config[defaultsConfigKey] = map[string]string{}
+	// Update it
+	if ks, err = clients.KnativeServing().Update(ks); err != nil {
+		t.Fatalf("KnativeServing %q failed to update: %v", names.KnativeServing, err)
+	}
+	// Verify the relevant configmap has been updated and does not contain any keys except "_example"
+	err = resources.WaitForConfigMap(defaultsConfigMapName, clients.KubeClient.Kube, func(m map[string]string) bool {
+		_, exampleExists := m["_example"]
+		return len(m) == 1 && exampleExists
+	})
+	if err != nil {
+		t.Fatal("The operator failed to update the configmap")
+	}
+
+	// Now remove the config from the spec and update
+	ks.Spec = v1alpha1.KnativeServingSpec{}
+	if ks, err = clients.KnativeServing().Update(ks); err != nil {
+		t.Fatalf("KnativeServing %q failed to update: %v", names.KnativeServing, err)
+	}
+	// And verify the configmap entry is gone
+	err = resources.WaitForConfigMap(loggingConfigMapName, clients.KubeClient.Kube, func(m map[string]string) bool {
+		_, exists := m["loglevel.controller"]
+		return !exists
+	})
+	if err != nil {
+		t.Fatal("The operator failed to revert the configmap")
+	}
+}
+
+// deploymentRecreation verify whether all the deployments for knative serving are able to recreate, when they are deleted.
+func deploymentRecreation(t *testing.T, clients *test.Clients, names test.ResourceNames) {
+	dpList, err := clients.KubeClient.Kube.AppsV1().Deployments(names.Namespace).List(metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get any deployment under the namespace %q: %v",
+			test.ServingOperatorNamespace, err)
+	}
+	if len(dpList.Items) == 0 {
+		t.Fatalf("No deployment under the namespace %q was found",
+			test.ServingOperatorNamespace)
+	}
+	// Delete the first deployment and verify the operator recreates it
+	deployment := dpList.Items[0]
+	if err := clients.KubeClient.Kube.AppsV1().Deployments(deployment.Namespace).Delete(deployment.Name,
+		&metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("Failed to delete deployment %s/%s: %v", deployment.Namespace, deployment.Name, err)
+	}
+
+	waitErr := wait.PollImmediate(resources.Interval, resources.Timeout, func() (bool, error) {
+		dep, err := clients.KubeClient.Kube.AppsV1().Deployments(deployment.Namespace).Get(deployment.Name, metav1.GetOptions{})
+		if err != nil {
+			// If the deployment is not found, we continue to wait for the availability.
+			if apierrs.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return resources.IsDeploymentAvailable(dep)
+	})
+
+	if waitErr != nil {
+		t.Fatalf("The deployment %s/%s failed to reach the desired state: %v", deployment.Namespace, deployment.Name, err)
+	}
+
+	if _, err := resources.WaitForKnativeServingState(clients.KnativeServing(), test.ServingOperatorName,
+		resources.IsKnativeServingReady); err != nil {
+		t.Fatalf("KnativeService %q failed to reach the desired state: %v", test.ServingOperatorName, err)
+	}
+	t.Logf("The deployment %s/%s reached the desired state.", deployment.Namespace, deployment.Name)
+}
+
+// knativeServingDelete deletes tha KnativeServing to see if all resources will be deleted
+func knativeServingDelete(t *testing.T, clients *test.Clients, names test.ResourceNames) {
+	if err := clients.KnativeServing().Delete(names.KnativeServing, &metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("KnativeServing %q failed to delete: %v", names.KnativeServing, err)
+	}
+	_, b, _, _ := runtime.Caller(0)
+	m, err := mf.NewManifest(filepath.Join((filepath.Dir(b)+"/.."), "config/"), false, clients.Config)
+	if err != nil {
+		t.Fatal("Failed to load manifest", err)
+	}
+	if err := verifyNoKnativeServings(clients); err != nil {
+		t.Fatal(err)
+	}
+	for _, u := range m.Resources {
+		if u.GetKind() == "Namespace" {
+			// The namespace should be skipped, because when the CR is removed, the Manifest to be removed has
+			// been modified, since the namespace can be injected.
+			continue
+		}
+		waitErr := wait.PollImmediate(resources.Interval, resources.Timeout, func() (bool, error) {
+			gvrs, _ := meta.UnsafeGuessKindToResource(u.GroupVersionKind())
+			if _, err := clients.Dynamic.Resource(gvrs).Get(u.GetName(), metav1.GetOptions{}); apierrs.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		})
+
+		if waitErr != nil {
+			t.Fatalf("The %s %s failed to be deleted: %v", u.GetKind(), u.GetName(), waitErr)
+		}
+		t.Logf("The %s %s has been deleted.", u.GetKind(), u.GetName())
+	}
+}
+
+func verifyNoKnativeServings(clients *test.Clients) error {
+	servings, err := clients.KnativeServingAll().List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	if len(servings.Items) > 0 {
+		return errors.New("Unable to verify cluster-scoped resources are deleted if any KnativeServing exists")
+	}
+	return nil
+}

--- a/test/e2e/knativeservingdeployment.go
+++ b/test/e2e/knativeservingdeployment.go
@@ -31,8 +31,10 @@ import (
 	"knative.dev/serving-operator/test/resources"
 )
 
-func testKnativeServingDeployment(t *testing.T) {
+func testKnativeServingDeployment(ctx *test.Context) {
 
+	t := ctx.T()
+	r := ctx.Runner()
 	cancel := logstream.Start(t)
 	defer cancel()
 	clients := Setup(t)
@@ -51,23 +53,23 @@ func testKnativeServingDeployment(t *testing.T) {
 	}
 
 	// Test if KnativeServing can reach the READY status
-	t.Run("create", func(t *testing.T) {
+	r.Run("create", func(t *testing.T) {
 		knativeServingVerify(t, clients, names)
 	})
 
-	t.Run("configure", func(t *testing.T) {
+	r.Run("configure", func(t *testing.T) {
 		knativeServingVerify(t, clients, names)
 		knativeServingConfigure(t, clients, names)
 	})
 
 	// Delete the deployments one by one to see if they will be recreated.
-	t.Run("restore", func(t *testing.T) {
+	r.Run("restore", func(t *testing.T) {
 		knativeServingVerify(t, clients, names)
 		deploymentRecreation(t, clients, names)
 	})
 
 	// Delete the KnativeServing to see if all resources will be removed
-	t.Run("delete", func(t *testing.T) {
+	r.Run("delete", func(t *testing.T) {
 		knativeServingVerify(t, clients, names)
 		knativeServingDelete(t, clients, names)
 	})

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -19,9 +19,19 @@ limitations under the License.
 
 package test
 
-const (
+import "os"
+
+var (
 	// ServingOperatorNamespace is the default namespace for serving operator e2e tests
-	ServingOperatorNamespace = "operator-tests"
+	ServingOperatorNamespace = getenv("TEST_NAMESPACE", "operator-tests")
 	// ServingOperatorName is the default operator name for serving operator e2e tests
-	ServingOperatorName = "knative-serving"
+	ServingOperatorName = getenv("TEST_RESOURCE", "knative-serving")
 )
+
+func getenv(name, defaultValue string) string {
+	value, set := os.LookupEnv(name)
+	if !set {
+		value = defaultValue
+	}
+	return value
+}

--- a/test/spec.go
+++ b/test/spec.go
@@ -1,5 +1,3 @@
-// +build e2e
-
 /*
 Copyright 2019 The Knative Authors
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,13 +11,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package test
 
-import (
-	"testing"
-)
+import "testing"
 
-// TestKnativeServingDeployment verifies the KnativeServing creation, deployment recreation, and KnativeServing deletion.
-func TestKnativeServingDeployment(t *testing.T) {
-	testKnativeServingDeployment(t)
+// Specification describes a test with name and method that will be use as test
+type Specification struct {
+	Name string
+	Func func(*testing.T)
+}
+
+// NewSpec creates a new test specification
+func NewSpec(name string, lambda func(*testing.T)) Specification {
+	return Specification{
+		Name: name,
+		Func: lambda,
+	}
 }

--- a/test/spec.go
+++ b/test/spec.go
@@ -13,18 +13,84 @@ limitations under the License.
 
 package test
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // Specification describes a test with name and method that will be use as test
 type Specification struct {
-	Name string
-	Func func(*testing.T)
+	regularSpec *regularSpecification
+	contextSpec *contextualSpecification
 }
 
 // NewSpec creates a new test specification
-func NewSpec(name string, lambda func(*testing.T)) Specification {
+func NewSpec(name string, testfunc func(t *testing.T)) Specification {
 	return Specification{
-		Name: name,
-		Func: lambda,
+		regularSpec: &regularSpecification{
+			name:     name,
+			testfunc: testfunc,
+		},
+		contextSpec: nil,
 	}
+}
+
+// NewContextualSpec creates a new test specification that uses context
+func NewContextualSpec(name string, testfunc func(ctx *Context)) Specification {
+	return Specification{
+		regularSpec: nil,
+		contextSpec: &contextualSpecification{
+			name:     name,
+			testfunc: testfunc,
+		},
+	}
+}
+
+// Skip will skip a test by it's composite name
+func Skip(testname string, args ...interface{}) Specification {
+	return NewSpec(testname, func(t *testing.T) {
+		t.Skip(args)
+	})
+}
+
+// Skipf will skip a test by it's composite name
+func Skipf(testname string, format string, args ...interface{}) Specification {
+	return NewSpec(testname, func(t *testing.T) {
+		t.Skipf(format, args)
+	})
+}
+
+type regularSpecification struct {
+	name     string
+	testfunc func(t *testing.T)
+}
+
+type contextualSpecification struct {
+	name     string
+	testfunc func(ctx *Context)
+}
+
+func (spec Specification) contextual() bool {
+	return spec.regularSpec == nil && spec.contextSpec != nil
+}
+
+func (spec Specification) name() string {
+	if spec.contextual() {
+		return spec.contextSpec.name
+	}
+	return spec.regularSpec.name
+}
+
+func (spec Specification) matchesNameInContext(name string, ctx *Context) bool {
+	candidate := strings.Join(ctx.activeTests[:], "/") + "/" + name
+	return spec.name() == candidate
+}
+
+func (spec Specification) testfunc(ctx *Context) func(t *testing.T) {
+	if spec.contextual() {
+		return func(t *testing.T) {
+			spec.contextSpec.testfunc(ctx)
+		}
+	}
+	return spec.regularSpec.testfunc
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Rely on PR #223
* Expose e2e test as a compliance suite (dbfbf2c)
* Add a test context to fine tune compliance suite testing (5d95dd6)

### Proposed changes details

#### Expose e2e test as a compliance suite (dbfbf2c)

As a knative vendor we would like to execute tests from upstream knative in out productized code's test plans.

To do that, I propose this minor change that would result in type safe way of reusing upstream test code, by vendoring it in our code. It involves moving e2e test to regular `.go` file, instead of `_test.go` file. In that way we can call that code from our test suite.

#### Add a test context to fine tune compliance suite testing (5d95dd6)

Sometimes upstream tests could not pass yet. That's natural as vendors will always be behind upstream code. In that case we need a mechanism that will let us skip parts of the tests.

That was implemented in `test.Context` object.

### Example usage

There is already created a PR openshift-knative/serverless-operator#32 that uses this concept. Below I highlighted a key test file from that PR (note that we are using [0.9 version](https://github.com/cardil/serving-operator/tree/feature/v0.9-reuse-tests-on-productized) of this change):

```go
package e2e

import (
	"testing"

	"github.com/openshift-knative/serverless-operator/test"
	upstreame2e "knative.dev/serving-operator/test/e2e"
	upstreamtest "knative.dev/serving-operator/test"
)

func TestUpstreamKnativeServingOperator(t *testing.T) {
	upstreamtest.ServingOperatorNamespace = "knative-serving"
	suite := upstreame2e.ComplianceSuite()
	ctx := test.SetupClusterAdmin(t)

	defer test.CleanupAll(ctx)
	test.CleanupOnInterrupt(t, func() { test.CleanupAll(ctx) })

	createSubscriptionAndWaitForCSVtoSucceed(t, ctx) // <1>

	skipConfigureSubTest := upstreamtest.Skip(
		"TestKnativeServingDeployment/configure",
		"Skip due to SRVKS-241") // <2>

	upstreamtest.
		NewContext(t).
		WithOverride(skipConfigureSubTest).
		RunSuite(suite) // <3>

	undeployServerlessOperatorAndCheckDependentOperatorsRemoved(t, ctx) // <4>
}
```

* `<1>` setup of our Serverless operator
* `<2>` registering a skip for `TestKnativeServingDeployment/configure` that we are not supporting at this point
* `<3>` actual compliance suite execution
* `<4>` teardown of our Serverless operator

**Release Note**

```release-note
NONE
```
