### PR TITLE
Update to latest manifestival

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -316,12 +316,12 @@
   version = "v0.3.8"
 
 [[projects]]
-  branch = "immutable-transform"
-  digest = "1:0c097d7b8850cf0e75aa9a44e491efe1d42098f8b5e099921d68f219c92581f5"
+  branch = "client-go"
+  digest = "1:ca0e2c3f72dd218000ee434b91b9f082a7d1f6a36dfd4dcb11b1e736928df367"
   name = "github.com/jcrossley3/manifestival"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "d0c6823509db87c4d4f4314fb25e539e980f4a69"
+  revision = "6a601d02309cdd03932c50d1f986570bc513289d"
 
 [[projects]]
   digest = "1:1f2aebae7e7c856562355ec0198d8ca2fa222fb05e5b1b66632a1fce39631885"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -50,7 +50,7 @@ required = [
 
 [[constraint]]
   name = "github.com/jcrossley3/manifestival"
-  branch = "immutable-transform"
+  branch = "client-go"
 
 [[constraint]]
   name = "knative.dev/pkg"

--- a/vendor/github.com/jcrossley3/manifestival/manifestival.go
+++ b/vendor/github.com/jcrossley3/manifestival/manifestival.go
@@ -22,6 +22,9 @@ func SetLogger(l logr.Logger) {
 	log = l.WithName("manifestival")
 }
 
+// Manifestival allows group application of a set of Kubernetes resources
+// (typically, a set of YAML files, aka a manifest) against a Kubernetes
+// apiserver.
 type Manifestival interface {
 	// Either updates or creates all resources in the manifest
 	ApplyAll() error
@@ -37,6 +40,8 @@ type Manifestival interface {
 	Transform(fns ...Transformer) (*Manifest, error)
 }
 
+// Manifest tracks a set of concrete resources which should be managed as a
+// group using a Kubernetes client provided by `NewManifest`.
 type Manifest struct {
 	Resources []unstructured.Unstructured
 	client    dynamic.Interface
@@ -45,6 +50,10 @@ type Manifest struct {
 
 var _ Manifestival = &Manifest{}
 
+// NewManifest creates a Manifest from a comma-separated set of yaml files or
+// directories (and subdirectories if the `recursive` option is set). The
+// Manifest will be evaluated using the supplied `config` against a particular
+// Kubernetes apiserver.
 func NewManifest(pathname string, recursive bool, config *rest.Config) (Manifest, error) {
 	log.Info("Reading manifest", "name", pathname)
 	resources, err := Parse(pathname, recursive)
@@ -62,6 +71,7 @@ func NewManifest(pathname string, recursive bool, config *rest.Config) (Manifest
 	return Manifest{Resources: resources, client: client, mapper: mapper}, nil
 }
 
+// ApplyAll updates or creates all resources in the manifest.
 func (f *Manifest) ApplyAll() error {
 	for _, spec := range f.Resources {
 		if err := f.Apply(&spec); err != nil {
@@ -71,6 +81,8 @@ func (f *Manifest) ApplyAll() error {
 	return nil
 }
 
+// Apply updates or creates a particular resource, which does not need to be
+// part of `Resources`, and will not be tracked.
 func (f *Manifest) Apply(spec *unstructured.Unstructured) error {
 	current, err := f.Get(spec)
 	if err != nil {
@@ -98,6 +110,7 @@ func (f *Manifest) Apply(spec *unstructured.Unstructured) error {
 	return nil
 }
 
+// DeleteAll removes all tracked `Resources` in the Manifest.
 func (f *Manifest) DeleteAll(opts *metav1.DeleteOptions) error {
 	a := make([]unstructured.Unstructured, len(f.Resources))
 	copy(a, f.Resources)
@@ -115,6 +128,8 @@ func (f *Manifest) DeleteAll(opts *metav1.DeleteOptions) error {
 	return nil
 }
 
+// Delete removes the specified objects, which do not need to be registered as
+// `Resources` in the Manifest.
 func (f *Manifest) Delete(spec *unstructured.Unstructured, opts *metav1.DeleteOptions) error {
 	current, err := f.Get(spec)
 	if current == nil && err == nil {
@@ -134,6 +149,8 @@ func (f *Manifest) Delete(spec *unstructured.Unstructured, opts *metav1.DeleteOp
 	return nil
 }
 
+// Get collects a full resource body (or `nil`) from a partial resource
+// supplied in `spec`.
 func (f *Manifest) Get(spec *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	resource, err := f.ResourceInterface(spec)
 	if err != nil {
@@ -149,6 +166,7 @@ func (f *Manifest) Get(spec *unstructured.Unstructured) (*unstructured.Unstructu
 	return result, err
 }
 
+// ResourceInterface returns an interface appropriate for the spec
 func (f *Manifest) ResourceInterface(spec *unstructured.Unstructured) (dynamic.ResourceInterface, error) {
 	gvk := spec.GroupVersionKind()
 	mapping, err := f.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
@@ -161,9 +179,12 @@ func (f *Manifest) ResourceInterface(spec *unstructured.Unstructured) (dynamic.R
 	return f.client.Resource(mapping.Resource).Namespace(spec.GetNamespace()), nil
 }
 
-// We need to preserve some target keys, specifically
-// 'metadata.resourceVersion' and 'spec.clusterIP'. So we only
-// overwrite fields set in our src resource.
+// UpdateChanged recursively merges JSON-style values in `src` into `tgt`.
+//
+// We need to preserve the top-level target keys, specifically
+// 'metadata.resourceVersion', 'spec.clusterIP', and any existing
+// entries in a ConfigMap's 'data' field. So we only overwrite fields
+// set in our src resource.
 // TODO: Use Patch instead
 func UpdateChanged(src, tgt map[string]interface{}) bool {
 	changed := false

--- a/vendor/github.com/jcrossley3/manifestival/transform.go
+++ b/vendor/github.com/jcrossley3/manifestival/transform.go
@@ -9,15 +9,18 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// Transform a resource from the manifest
+// Transformer transforms a resource from the manifest in place.
 type Transformer func(u *unstructured.Unstructured) error
 
+// Owner is a partial Kubernetes metadata schema.
 type Owner interface {
 	v1.Object
 	schema.ObjectKind
 }
 
-// If an error occurs, no resources are transformed
+// Transform applies an ordered set of Transformer functions to the
+// `Resources` in this Manifest.  If an error occurs, no resources are
+// transformed.
 func (f *Manifest) Transform(fns ...Transformer) (*Manifest, error) {
 	var results []unstructured.Unstructured
 	for i := 0; i < len(f.Resources); i++ {
@@ -35,7 +38,9 @@ func (f *Manifest) Transform(fns ...Transformer) (*Manifest, error) {
 	return &Manifest{Resources: results, client: f.client, mapper: f.mapper}, nil
 }
 
-// We assume all resources in the manifest live in the same namespace
+// InjectNamespace creates a Transformer which adds a namespace to existing
+// resources if appropriate. We assume all resources in the manifest live in
+// the same namespace.
 func InjectNamespace(ns string) Transformer {
 	namespace := resolveEnv(ns)
 	return func(u *unstructured.Unstructured) error {
@@ -50,6 +55,18 @@ func InjectNamespace(ns string) Transformer {
 					m["namespace"] = namespace
 				}
 			}
+		case "validatingwebhookconfiguration", "mutatingwebhookconfiguration":
+			hooks, _, _ := unstructured.NestedFieldNoCopy(u.Object, "webhooks")
+			for _, hook := range hooks.([]interface{}) {
+				m := hook.(map[string]interface{})
+				if c, ok := m["clientConfig"]; ok {
+					cfg := c.(map[string]interface{})
+					if s, ok := cfg["service"]; ok {
+						srv := s.(map[string]interface{})
+						srv["namespace"] = namespace
+					}
+				}
+			}
 		}
 		if !isClusterScoped(u.GetKind()) {
 			u.SetNamespace(namespace)
@@ -58,6 +75,8 @@ func InjectNamespace(ns string) Transformer {
 	}
 }
 
+// InjectOwner creates a Tranformer which adds an OwnerReference pointing to
+// `owner` to namespace-scoped objects.
 func InjectOwner(owner Owner) Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if !isClusterScoped(u.GetKind()) {

--- a/vendor/github.com/jcrossley3/manifestival/yaml.go
+++ b/vendor/github.com/jcrossley3/manifestival/yaml.go
@@ -79,8 +79,12 @@ func readDir(pathname string, recursive bool) ([]unstructured.Unstructured, erro
 	aggregated := []unstructured.Unstructured{}
 	for _, f := range list {
 		name := path.Join(pathname, f.Name())
-		pathDirOrFile, _ := os.Stat(name)
+		pathDirOrFile, err := os.Stat(name)
 		var els []unstructured.Unstructured
+
+		if os.IsNotExist(err) || os.IsPermission(err) {
+			return aggregated, err
+		}
 
 		switch {
 		case pathDirOrFile.IsDir() && recursive:
@@ -132,6 +136,9 @@ func decode(reader io.Reader) ([]unstructured.Unstructured, error) {
 
 // isURL checks whether or not the given path parses as a URL.
 func isURL(pathname string) bool {
+	if _, err := os.Lstat(pathname); err == nil {
+		return false
+	}
 	url, err := url.ParseRequestURI(pathname)
 	return err == nil && url.Scheme != ""
 }


### PR DESCRIPTION
Back on the `client-go` branch, with immutable transforms merged, some edgecase filesystem fixes (thanks @houshengbo), lint-free comments, and proper handling of injected namespaces in webhook resources (thanks @evankanderson) 