### PR TITLE
Remove the short name for consistent decision in Operation WG

### DIFF
--- a/config/300-serving-v1alpha1-knativeserving-crd.yaml
+++ b/config/300-serving-v1alpha1-knativeserving-crd.yaml
@@ -19,8 +19,6 @@ spec:
     listKind: KnativeServingList
     plural: knativeservings
     singular: knativeserving
-    shortNames:
-    - ks
   scope: Namespaced
   subresources:
     status: {}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


## Proposed Changes

* This PR removes the short name for the Knative Serving Operator CRD, since this is the decision made in operation WG.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
