### PR TITLE
Print error in knativeServingDelete

### DIFF
--- a/test/e2e/knativeservingdeployment_test.go
+++ b/test/e2e/knativeservingdeployment_test.go
@@ -241,7 +241,7 @@ func knativeServingDelete(t *testing.T, clients *test.Clients, names test.Resour
 		}
 		gvrs, _ := meta.UnsafeGuessKindToResource(u.GroupVersionKind())
 		if _, err := clients.Dynamic.Resource(gvrs).Get(u.GetName(), metav1.GetOptions{}); !apierrs.IsNotFound(err) {
-			t.Fatalf("The %s %s failed to be deleted", u.GetKind(), u.GetName())
+			t.Fatalf("The %s %s failed to be deleted: %v", u.GetKind(), u.GetName(), err)
 		}
 	}
 }


### PR DESCRIPTION
This makes a tiny change that knativeServingDelete prints missing error message.

Currently the error prints as:

```
    --- FAIL: TestKnativeServingDeployment/delete (30.65s)
        knativeservingdeployment_test.go:244: The CustomResourceDefinition ingresses.networking.internal.knative.dev failed to be deleted
```

and it is difficult to find the reason why `clients.Dynamic.Resource(gvrs).Get()` failed to delete.

/lint


**Release Note**

```release-note
NONE
```
