### PR TITLE
Add a comment about why cluster-admin is necessary.

### DIFF
--- a/config/role.yaml
+++ b/config/role.yaml
@@ -57,6 +57,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-operator
+# This is necessary in order to use cluster role aggregation.
 rules:
   - apiGroups: ["*"]
     resources: ["*"]


### PR DESCRIPTION
Unfortunately it appears that in order to use an aggregated
clusterrole we need the operator to be a cluster-admin.
This should help prevent confusion re: why we have both an
explicit list and a blanket `*/*` granted to the operator
service account.

See #282 

## Proposed Changes

* Add a (hopefully) helpful comment.

**Release Note**

NONE
