### PR TITLE
Restrict RBAC for Operator

### DIFF
--- a/config/role.yaml
+++ b/config/role.yaml
@@ -11,23 +11,99 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
-  creationTimestamp: null
+  name: knative-serving-operator-aggregated
+aggregationRule:
+  clusterRoleSelectors:
+# This (along with escalate below) allows the Operator to pick up any
+# roles that are provided to the admin of the cluster by knative serving
+# automatically.
+  - matchExpressions:
+      - {key: serving.knative.dev/release, operator: Exists}
+rules: [] # Rules are automatically filled in by the controller manager.
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
   name: knative-serving-operator
 rules:
 - apiGroups:
+  - operator.knative.dev
+  resources:
+  - '*'
+  verbs:
+  - '*'
+# Bootstrapping permissions.
+# Roles that are explicitly bound buch which are specified by this Operator
+# MUST be specified here with 'get' and 'bind'.
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  resourceNames:
+  - system:auth-delegator
+  verbs:
+  - bind
+  - get
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  resourceNames:
+  - extension-apiserver-authentication-reader
+  verbs:
+  - bind
+  - get
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - roles
+  verbs:
+  - create
+  - delete
+# Escalate is necessary in order to create a role using cluster role aggregation,
+# and to allow the Operator to bootstrap itself into the necessary set of
+# permissions, even as those continue to evolve upstream.
+  - escalate
+  - get
+  - list
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - list
+  - get
+  - update
+# Permissions required for Knative controller
+# infra.
+- apiGroups:
+  - apiregistration.k8s.io
+  resources:
+  - apiservices
+  verbs:
+  - update
+- apiGroups:
   - ""
   resources:
-  - pods
   - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - caching.internal.knative.dev
+  resources:
+  - images
   verbs:
   - '*'
 - apiGroups:
@@ -36,6 +112,26 @@ rules:
   - namespaces
   verbs:
   - get
+  - update
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:
@@ -44,41 +140,58 @@ rules:
   - replicasets
   - statefulsets
   verbs:
-  - '*'
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
   - create
+  - delete
+  - get
+  - list
+  - watch
 - apiGroups:
-  - apps
-  resourceNames:
-  - knative-serving-operator
+  - apiregistration.k8s.io
   resources:
-  - deployments/finalizers
+  - apiservices
   verbs:
-  - update
+  - create
+  - delete
+  - get
+  - list
 - apiGroups:
-  - operator.knative.dev
+  - autoscaling
   resources:
-  - '*'
+  - horizontalpodautoscalers
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
 - apiGroups:
   - coordination.k8s.io
   resources:
   - leases
   verbs:
   - '*'
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: knative-serving-operator
-# This is necessary in order to use cluster role aggregation.
-rules:
-  - apiGroups: ["*"]
-    resources: ["*"]
-    verbs: ["*"]
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+# Old resources that need cleaning up that are not in the knative-serving
+# namespace.
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - deployments
+  - horizontalpodautoscalers
+  resourceNames:
+  - knative-ingressgateway
+  verbs:
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - config-controller
+  verbs:
+  - delete

--- a/config/role_binding.yaml
+++ b/config/role_binding.yaml
@@ -11,19 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: knative-serving-operator
-subjects:
-- kind: ServiceAccount
-  name: knative-serving-operator
-roleRef:
-  kind: Role
-  name: knative-serving-operator
-  apiGroup: rbac.authorization.k8s.io
----
+# TODO: Consider restriction of non-aggregated role to knativeservings namespaces.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -32,6 +20,19 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: knative-serving-operator
+subjects:
+- kind: ServiceAccount
+  name: knative-serving-operator
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-serving-operator-aggregated
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: knative-serving-operator-aggregated
 subjects:
 - kind: ServiceAccount
   name: knative-serving-operator


### PR DESCRIPTION
Fixes #282

#374  is a base of this, you can solely review the YAML here
(and not the reconciler change) though you're welcome to review
that as well.

## Proposed Changes

By using the `escalate` verb on clusterroles, we allow the Operator
to have the ability to create any clusterrole. This prevents us from
needing to grant it `cluster-admin`.

Additionally, by having the Operator create an aggregated clusterrole
for itself (aggregating all clusteroles created by Knative Serving),
we pick up any permissions that the upstream dictate as necessary
by any component.

Any roles that are not created by upstream, but which are bound as
part of install are added with the `bind` verb to allow the Operator
to bind them without necessarily having the permissions they grant.

Some other permissions are needed to support controller infra
and are explicitly included, as well as some specific to the Operator
itself. An attempt at grouping these by sections is included, though
may be slightly out of sync (in particular: Controller infra / Specific
to this Operator may overlap).

Overall, this should keep the Operator roughly operating only on
Knative Serving resources (or things which can be operated
on by upstream).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Change RBAC to minimize permissions of Operator service account.
```
