### PR TITLE
Support reading KubeConfig from KUBECONFIG env var

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -19,7 +19,6 @@ import (
 	"flag"
 	"log"
 
-	"k8s.io/client-go/tools/clientcmd"
 	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/signals"
 	"knative.dev/serving-operator/pkg/reconciler/knativeserving"
@@ -28,7 +27,7 @@ import (
 func main() {
 	flag.Parse()
 
-	cfg, err := clientcmd.BuildConfigFromFlags(*knativeserving.MasterURL, *knativeserving.Kubeconfig)
+	cfg, err := sharedmain.GetConfig(*knativeserving.MasterURL, *knativeserving.Kubeconfig)
 	if err != nil {
 		log.Fatal("Error building kubeconfig", err)
 	}

--- a/pkg/reconciler/knativeserving/controller.go
+++ b/pkg/reconciler/knativeserving/controller.go
@@ -16,6 +16,7 @@ package knativeserving
 import (
 	"context"
 	"flag"
+	"knative.dev/pkg/injection/sharedmain"
 	"os"
 	"path/filepath"
 
@@ -23,7 +24,6 @@ import (
 	mf "github.com/manifestival/manifestival"
 	"go.uber.org/zap"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/clientcmd"
 	deploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -60,7 +60,7 @@ func NewController(
 
 	koDataDir := os.Getenv("KO_DATA_PATH")
 
-	cfg, err := clientcmd.BuildConfigFromFlags(*MasterURL, *Kubeconfig)
+	cfg, err := sharedmain.GetConfig(*MasterURL, *Kubeconfig)
 	if err != nil {
 		c.Logger.Error(err, "Error building kubeconfig")
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #292 

## Proposed Changes

* Backwards compatible change
* Only use `KUBECONFIG` if the command line argument is empty

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

Same PR for eventing operator: https://github.com/knative/eventing-operator/pull/100