### PR TITLE
Update to Manifestival v0.1.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -158,9 +158,12 @@
   version = "v4.6.0"
 
 [[projects]]
-  digest = "1:53becd66889185091b58ea3fc49294996f2179fb05a89702f4de7d15e581b509"
+  digest = "1:b49dd34bdf52d28b69e41181bed939bdf48e1152ef54d21db643e3c50b3b33c0"
   name = "github.com/go-logr/logr"
-  packages = ["."]
+  packages = [
+    ".",
+    "testing",
+  ]
   pruneopts = "NUT"
   revision = "9fb12b3b21c5415d16ac18dc5cd42c1cfdd40c4e"
   version = "v0.1.0"
@@ -379,15 +382,23 @@
   version = "v0.7.0"
 
 [[projects]]
-  branch = "client-go"
-  digest = "1:2643e5c61ae47443e8844998511a380db0aee817704128ddc6930ba21c2d3a07"
+  branch = "master"
+  digest = "1:884250c3c0343f0c1533b7d9251fdb183a6ece6e896b69de6b254c60389c5bc9"
+  name = "github.com/manifestival/client-go-client"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "3428131c176ca4d181b792517fd08e60c17af706"
+
+[[projects]]
+  branch = "master"
+  digest = "1:b9a54a63e2936b1d3dac7d39d0c11c092fa13bb34c3eb8a307317da5766941ee"
   name = "github.com/manifestival/manifestival"
   packages = [
     ".",
     "patch",
   ]
   pruneopts = "NUT"
-  revision = "cfc8488761512632803a70056a0284cb5b0ff0d1"
+  revision = "17b3d45d5e509af3146b934e9d9ca4cd90ed79c4"
 
 [[projects]]
   digest = "1:5985ef4caf91ece5d54817c11ea25f182697534f8ae6521eadcd628c142ac4b6"
@@ -422,12 +433,12 @@
   version = "v0.2.2"
 
 [[projects]]
-  digest = "1:4af5ef5028af0c996043a4ed5731c51a649fc3d27d700a2d88a47d51591ab993"
+  digest = "1:a9c110560d6c7ae97fe37ca11a1eb711c41cd154121b36bee7284289d8d21739"
   name = "github.com/operator-framework/operator-sdk"
   packages = ["pkg/restmapper"]
   pruneopts = "NUT"
-  revision = "78c472461e75e6c64589cfadf577a2004b8a26b3"
-  version = "v0.8.0"
+  revision = "e35ec7b722ba095e6438f63fafb9e7326870b486"
+  version = "v0.15.1"
 
 [[projects]]
   digest = "1:4047c378584616813d610c9f993bf90dd0d07aed8d94bd3bc299cd35ececdcba"
@@ -1371,6 +1382,7 @@
   input-imports = [
     "github.com/go-logr/zapr",
     "github.com/go-openapi/spec",
+    "github.com/manifestival/client-go-client",
     "github.com/manifestival/manifestival",
     "github.com/pkg/errors",
     "go.opencensus.io/stats",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -382,15 +382,14 @@
   version = "v0.7.0"
 
 [[projects]]
-  branch = "master"
   digest = "1:884250c3c0343f0c1533b7d9251fdb183a6ece6e896b69de6b254c60389c5bc9"
   name = "github.com/manifestival/client-go-client"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "3428131c176ca4d181b792517fd08e60c17af706"
+  revision = "c29246a03e39f027084d68a6be8bbb7357095741"
+  version = "v0.1.0"
 
 [[projects]]
-  branch = "master"
   digest = "1:b9a54a63e2936b1d3dac7d39d0c11c092fa13bb34c3eb8a307317da5766941ee"
   name = "github.com/manifestival/manifestival"
   packages = [
@@ -398,7 +397,8 @@
     "patch",
   ]
   pruneopts = "NUT"
-  revision = "17b3d45d5e509af3146b934e9d9ca4cd90ed79c4"
+  revision = "f5dd205675d3301a65eeb90aa4c7f793b8c0897f"
+  version = "v0.1.0"
 
 [[projects]]
   digest = "1:5985ef4caf91ece5d54817c11ea25f182697534f8ae6521eadcd628c142ac4b6"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -50,7 +50,7 @@ required = [
 
 [[constraint]]
   name = "github.com/manifestival/manifestival"
-  branch = "client-go"
+  branch = "master"
 
 [[override]]
   name = "knative.dev/pkg"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -50,7 +50,7 @@ required = [
 
 [[constraint]]
   name = "github.com/manifestival/manifestival"
-  branch = "master"
+  version = "0.1.0"
 
 [[override]]
   name = "knative.dev/pkg"

--- a/pkg/reconciler/knativeserving/controller.go
+++ b/pkg/reconciler/knativeserving/controller.go
@@ -39,7 +39,6 @@ const (
 )
 
 var (
-	recursive  = flag.Bool("recursive", false, "If filename is a directory, process all manifests recursively")
 	MasterURL  = flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	Kubeconfig = flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 )
@@ -68,7 +67,6 @@ func NewController(
 
 	config, err := mfc.NewManifest(filepath.Join(koDataDir, "knative-serving/"),
 		cfg,
-		mf.UseRecursive(*recursive),
 		mf.UseLogger(zapr.NewLogger(c.Logger.Desugar()).WithName("manifestival")))
 	if err != nil {
 		c.Logger.Error(err, "Error creating the Manifest for knative-serving")

--- a/pkg/reconciler/knativeserving/controller.go
+++ b/pkg/reconciler/knativeserving/controller.go
@@ -22,8 +22,8 @@ import (
 	"knative.dev/pkg/injection/sharedmain"
 
 	"github.com/go-logr/zapr"
+	mfc "github.com/manifestival/client-go-client"
 	mf "github.com/manifestival/manifestival"
-	"go.uber.org/zap"
 	"k8s.io/client-go/tools/cache"
 	deploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
 	"knative.dev/pkg/configmap"
@@ -66,8 +66,10 @@ func NewController(
 		c.Logger.Error(err, "Error building kubeconfig")
 	}
 
-	mf.SetLogger(zapr.NewLogger(zap.NewExample()))
-	config, err := mf.NewManifest(filepath.Join(koDataDir, "knative-serving/"), *recursive, cfg)
+	config, err := mfc.NewManifest(filepath.Join(koDataDir, "knative-serving/"),
+		cfg,
+		mf.UseRecursive(*recursive),
+		mf.UseLogger(zapr.NewLogger(c.Logger.Desugar()).WithName("manifestival")))
 	if err != nil {
 		c.Logger.Error(err, "Error creating the Manifest for knative-serving")
 		os.Exit(1)

--- a/pkg/reconciler/knativeserving/knativeserving_controller.go
+++ b/pkg/reconciler/knativeserving/knativeserving_controller.go
@@ -252,7 +252,7 @@ func (r *Reconciler) delete(instance *servingv1alpha1.KnativeServing) error {
 		return nil
 	}
 	if len(r.servings) == 0 {
-		if err := r.config.DeleteAll(&metav1.DeleteOptions{}); err != nil {
+		if err := r.config.DeleteAll(); err != nil {
 			return err
 		}
 	}
@@ -274,17 +274,17 @@ func (r *Reconciler) deleteObsoleteResources(manifest *mf.Manifest, instance *se
 	resource.SetName("knative-ingressgateway")
 	resource.SetAPIVersion("v1")
 	resource.SetKind("Service")
-	if err := manifest.Delete(resource, &metav1.DeleteOptions{}); err != nil {
+	if err := manifest.Delete(resource); err != nil {
 		return err
 	}
 	resource.SetAPIVersion("apps/v1")
 	resource.SetKind("Deployment")
-	if err := manifest.Delete(resource, &metav1.DeleteOptions{}); err != nil {
+	if err := manifest.Delete(resource); err != nil {
 		return err
 	}
 	resource.SetAPIVersion("autoscaling/v1")
 	resource.SetKind("HorizontalPodAutoscaler")
-	if err := manifest.Delete(resource, &metav1.DeleteOptions{}); err != nil {
+	if err := manifest.Delete(resource); err != nil {
 		return err
 	}
 	// config-controller from 0.5
@@ -292,7 +292,7 @@ func (r *Reconciler) deleteObsoleteResources(manifest *mf.Manifest, instance *se
 	resource.SetName("config-controller")
 	resource.SetAPIVersion("v1")
 	resource.SetKind("ConfigMap")
-	if err := manifest.Delete(resource, &metav1.DeleteOptions{}); err != nil {
+	if err := manifest.Delete(resource); err != nil {
 		return err
 	}
 	return nil

--- a/test/resources/verify.go
+++ b/test/resources/verify.go
@@ -20,7 +20,7 @@ import (
 	"runtime"
 	"testing"
 
-	mf "github.com/manifestival/manifestival"
+	mf "github.com/manifestival/client-go-client"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -202,7 +202,7 @@ func KSOperatorCRDelete(t *testing.T, clients *test.Clients, names test.Resource
 		t.Fatal("Timed out waiting on KnativeServing to delete", err)
 	}
 	_, b, _, _ := runtime.Caller(0)
-	m, err := mf.NewManifest(filepath.Join((filepath.Dir(b)+"/.."), "config/"), false, clients.Config)
+	m, err := mf.NewManifest(filepath.Join((filepath.Dir(b)+"/.."), "config/"), clients.Config)
 	if err != nil {
 		t.Fatal("Failed to load manifest", err)
 	}

--- a/third_party/VENDOR-LICENSE
+++ b/third_party/VENDOR-LICENSE
@@ -3930,6 +3930,213 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 ===========================================================
+Import: knative.dev/serving-operator/vendor/github.com/manifestival/client-go-client
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+
+===========================================================
 Import: knative.dev/serving-operator/vendor/github.com/manifestival/manifestival
 
                                  Apache License

--- a/vendor/github.com/go-logr/logr/testing/null.go
+++ b/vendor/github.com/go-logr/logr/testing/null.go
@@ -1,0 +1,32 @@
+package testing
+
+import "github.com/go-logr/logr"
+
+// NullLogger is a logr.Logger that does nothing.
+type NullLogger struct{}
+
+var _ logr.Logger = NullLogger{}
+
+func (_ NullLogger) Info(_ string, _ ...interface{}) {
+	// Do nothing.
+}
+
+func (_ NullLogger) Enabled() bool {
+	return false
+}
+
+func (_ NullLogger) Error(_ error, _ string, _ ...interface{}) {
+	// Do nothing.
+}
+
+func (log NullLogger) V(_ int) logr.InfoLogger {
+	return log
+}
+
+func (log NullLogger) WithName(_ string) logr.Logger {
+	return log
+}
+
+func (log NullLogger) WithValues(_ ...interface{}) logr.Logger {
+	return log
+}

--- a/vendor/github.com/go-logr/logr/testing/test.go
+++ b/vendor/github.com/go-logr/logr/testing/test.go
@@ -1,0 +1,39 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+// TestLogger is a logr.Logger that prints through a testing.T object.
+// Only error logs will have any effect.
+type TestLogger struct {
+	T *testing.T
+}
+
+var _ logr.Logger = TestLogger{}
+
+func (_ TestLogger) Info(_ string, _ ...interface{}) {
+	// Do nothing.
+}
+
+func (_ TestLogger) Enabled() bool {
+	return false
+}
+
+func (log TestLogger) Error(err error, msg string, args ...interface{}) {
+	log.T.Logf("%s: %v -- %v", msg, err, args)
+}
+
+func (log TestLogger) V(v int) logr.InfoLogger {
+	return log
+}
+
+func (log TestLogger) WithName(_ string) logr.Logger {
+	return log
+}
+
+func (log TestLogger) WithValues(_ ...interface{}) logr.Logger {
+	return log
+}

--- a/vendor/github.com/manifestival/client-go-client/LICENSE
+++ b/vendor/github.com/manifestival/client-go-client/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/manifestival/client-go-client/client.go
+++ b/vendor/github.com/manifestival/client-go-client/client.go
@@ -1,0 +1,85 @@
+package client
+
+import (
+	mf "github.com/manifestival/manifestival"
+	"github.com/operator-framework/operator-sdk/pkg/restmapper"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+func NewManifest(pathname string, config *rest.Config, opts ...mf.Option) (mf.Manifest, error) {
+	client, err := NewClient(config)
+	if err != nil {
+		return mf.Manifest{}, err
+	}
+	return mf.NewManifest(pathname, append(opts, mf.UseClient(client))...)
+}
+
+func NewClient(config *rest.Config) (mf.Client, error) {
+	client, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	mapper, err := restmapper.NewDynamicRESTMapper(config)
+	if err != nil {
+		return nil, err
+	}
+	return &clientGoClient{client: client, mapper: mapper}, nil
+}
+
+type clientGoClient struct {
+	client dynamic.Interface
+	mapper meta.RESTMapper
+}
+
+// verify implementation
+var _ mf.Client = (*clientGoClient)(nil)
+
+func (c *clientGoClient) Create(obj *unstructured.Unstructured, options *metav1.CreateOptions) error {
+	resource, err := c.resourceInterface(obj)
+	if err != nil {
+		return err
+	}
+	_, err = resource.Create(obj, *options)
+	return err
+}
+
+func (c *clientGoClient) Update(obj *unstructured.Unstructured, options *metav1.UpdateOptions) error {
+	resource, err := c.resourceInterface(obj)
+	if err != nil {
+		return err
+	}
+	_, err = resource.Update(obj, *options)
+	return err
+}
+
+func (c *clientGoClient) Delete(obj *unstructured.Unstructured, options *metav1.DeleteOptions) error {
+	resource, err := c.resourceInterface(obj)
+	if err != nil {
+		return err
+	}
+	return resource.Delete(obj.GetName(), options)
+}
+
+func (c *clientGoClient) Get(obj *unstructured.Unstructured, options *metav1.GetOptions) (*unstructured.Unstructured, error) {
+	resource, err := c.resourceInterface(obj)
+	if err != nil {
+		return nil, err
+	}
+	return resource.Get(obj.GetName(), *options)
+}
+
+func (c *clientGoClient) resourceInterface(obj *unstructured.Unstructured) (dynamic.ResourceInterface, error) {
+	gvk := obj.GroupVersionKind()
+	mapping, err := c.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return nil, err
+	}
+	if mapping.Scope.Name() == meta.RESTScopeNameRoot {
+		return c.client.Resource(mapping.Resource), nil
+	}
+	return c.client.Resource(mapping.Resource).Namespace(obj.GetNamespace()), nil
+}

--- a/vendor/github.com/manifestival/manifestival/client.go
+++ b/vendor/github.com/manifestival/manifestival/client.go
@@ -1,0 +1,93 @@
+package manifestival
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type Client interface {
+	Create(obj *unstructured.Unstructured, options *metav1.CreateOptions) error
+	Update(obj *unstructured.Unstructured, options *metav1.UpdateOptions) error
+	Delete(obj *unstructured.Unstructured, options *metav1.DeleteOptions) error
+	Get(obj *unstructured.Unstructured, options *metav1.GetOptions) (*unstructured.Unstructured, error)
+}
+
+// Functional options pattern
+type ClientOption func(*ClientOptions)
+
+type ClientOptions struct {
+	DryRun             []string
+	FieldManager       string
+	GracePeriodSeconds *int64
+	Preconditions      *metav1.Preconditions
+	PropagationPolicy  *metav1.DeletionPropagation
+	ResourceVersion    string
+}
+
+func NewOptions(opts ...ClientOption) *ClientOptions {
+	result := &ClientOptions{}
+	for _, opt := range opts {
+		opt(result)
+	}
+	return result
+}
+
+func (o *ClientOptions) ForCreate() *metav1.CreateOptions {
+	return &metav1.CreateOptions{
+		DryRun:       o.DryRun,
+		FieldManager: o.FieldManager,
+	}
+}
+
+func (o *ClientOptions) ForUpdate() *metav1.UpdateOptions {
+	return &metav1.UpdateOptions{
+		DryRun:       o.DryRun,
+		FieldManager: o.FieldManager,
+	}
+}
+
+func (o *ClientOptions) ForDelete() *metav1.DeleteOptions {
+	return &metav1.DeleteOptions{
+		DryRun:             o.DryRun,
+		GracePeriodSeconds: o.GracePeriodSeconds,
+		Preconditions:      o.Preconditions,
+		PropagationPolicy:  o.PropagationPolicy,
+	}
+}
+
+func (o *ClientOptions) ForGet() *metav1.GetOptions {
+	return &metav1.GetOptions{
+		ResourceVersion: o.ResourceVersion,
+	}
+}
+
+func DryRun(v []string) ClientOption {
+	return func(o *ClientOptions) {
+		o.DryRun = v
+	}
+}
+func FieldManager(v string) ClientOption {
+	return func(o *ClientOptions) {
+		o.FieldManager = v
+	}
+}
+func GracePeriodSeconds(v *int64) ClientOption {
+	return func(o *ClientOptions) {
+		o.GracePeriodSeconds = v
+	}
+}
+func Preconditions(v *metav1.Preconditions) ClientOption {
+	return func(o *ClientOptions) {
+		o.Preconditions = v
+	}
+}
+func PropagationPolicy(v *metav1.DeletionPropagation) ClientOption {
+	return func(o *ClientOptions) {
+		o.PropagationPolicy = v
+	}
+}
+func ResourceVersion(v string) ClientOption {
+	return func(o *ClientOptions) {
+		o.ResourceVersion = v
+	}
+}

--- a/vendor/github.com/manifestival/manifestival/manifestival.go
+++ b/vendor/github.com/manifestival/manifestival/manifestival.go
@@ -4,39 +4,27 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/go-logr/zapr"
+	"github.com/go-logr/logr/testing"
 	"github.com/manifestival/manifestival/patch"
-	"github.com/operator-framework/operator-sdk/pkg/restmapper"
-	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/rest"
 )
-
-var log = zapr.NewLogger(zap.NewExample())
-
-func SetLogger(l logr.Logger) {
-	log = l.WithName("manifestival")
-}
 
 // Manifestival allows group application of a set of Kubernetes resources
 // (typically, a set of YAML files, aka a manifest) against a Kubernetes
 // apiserver.
 type Manifestival interface {
 	// Either updates or creates all resources in the manifest
-	ApplyAll() error
+	ApplyAll(opts ...ClientOption) error
 	// Updates or creates a particular resource
-	Apply(*unstructured.Unstructured) error
+	Apply(spec *unstructured.Unstructured, opts ...ClientOption) error
 	// Deletes all resources in the manifest
-	DeleteAll(opts *metav1.DeleteOptions) error
+	DeleteAll(opts ...ClientOption) error
 	// Deletes a particular resource
-	Delete(spec *unstructured.Unstructured, opts *metav1.DeleteOptions) error
+	Delete(spec *unstructured.Unstructured, opts ...ClientOption) error
 	// Returns a copy of the resource from the api server, nil if not found
-	Get(spec *unstructured.Unstructured) (*unstructured.Unstructured, error)
+	Get(spec *unstructured.Unstructured, opts ...ClientOption) (*unstructured.Unstructured, error)
 	// Transforms the resources within a Manifest
 	Transform(fns ...Transformer) (*Manifest, error)
 }
@@ -45,8 +33,8 @@ type Manifestival interface {
 // group using a Kubernetes client provided by `NewManifest`.
 type Manifest struct {
 	Resources []unstructured.Unstructured
-	client    dynamic.Interface
-	mapper    meta.RESTMapper
+	client    Client
+	log       logr.Logger
 }
 
 var _ Manifestival = &Manifest{}
@@ -55,27 +43,27 @@ var _ Manifestival = &Manifest{}
 // directories (and subdirectories if the `recursive` option is set). The
 // Manifest will be evaluated using the supplied `config` against a particular
 // Kubernetes apiserver.
-func NewManifest(pathname string, recursive bool, config *rest.Config) (Manifest, error) {
+func NewManifest(pathname string, opts ...Option) (Manifest, error) {
+	o := &options{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	log := o.logger
+	if log == nil {
+		log = testing.NullLogger{}
+	}
 	log.Info("Reading manifest", "name", pathname)
-	resources, err := Parse(pathname, recursive)
+	resources, err := Parse(pathname, o.recursive)
 	if err != nil {
 		return Manifest{}, err
 	}
-	client, err := dynamic.NewForConfig(config)
-	if err != nil {
-		return Manifest{Resources: resources}, err
-	}
-	mapper, err := restmapper.NewDynamicRESTMapper(config)
-	if err != nil {
-		return Manifest{Resources: resources}, err
-	}
-	return Manifest{Resources: resources, client: client, mapper: mapper}, nil
+	return Manifest{Resources: resources, client: o.client, log: log}, nil
 }
 
 // ApplyAll updates or creates all resources in the manifest.
-func (f *Manifest) ApplyAll() error {
+func (f *Manifest) ApplyAll(opts ...ClientOption) error {
 	for _, spec := range f.Resources {
-		if err := f.Apply(&spec); err != nil {
+		if err := f.Apply(&spec, opts...); err != nil {
 			return err
 		}
 	}
@@ -84,20 +72,17 @@ func (f *Manifest) ApplyAll() error {
 
 // Apply updates or creates a particular resource, which does not need to be
 // part of `Resources`, and will not be tracked.
-func (f *Manifest) Apply(spec *unstructured.Unstructured) error {
-	current, err := f.Get(spec)
+func (f *Manifest) Apply(spec *unstructured.Unstructured, opts ...ClientOption) error {
+	current, err := f.Get(spec, opts...)
 	if err != nil {
 		return err
 	}
-	resource, err := f.ResourceInterface(spec)
-	if err != nil {
-		return err
-	}
+	options := NewOptions(opts...)
 	if current == nil {
-		logResource("Creating", spec)
+		f.logResource("Creating", spec)
 		annotate(spec, v1.LastAppliedConfigAnnotation, patch.MakeLastAppliedConfig(spec))
 		annotate(spec, "manifestival", resourceCreated)
-		if _, err = resource.Create(spec, metav1.CreateOptions{}); err != nil {
+		if err = f.client.Create(spec.DeepCopy(), options.ForCreate()); err != nil {
 			return err
 		}
 	} else {
@@ -106,12 +91,12 @@ func (f *Manifest) Apply(spec *unstructured.Unstructured) error {
 			return err
 		}
 		if patch.IsRequired() {
-			log.Info("Merging", "diff", patch)
+			f.log.Info("Merging", "diff", patch)
 			if err := patch.Merge(current); err != nil {
 				return err
 			}
-			logResource("Updating", current)
-			if _, err = resource.Update(current, metav1.UpdateOptions{}); err != nil {
+			f.logResource("Updating", current)
+			if err = f.client.Update(current, options.ForUpdate()); err != nil {
 				return err
 			}
 		}
@@ -120,7 +105,7 @@ func (f *Manifest) Apply(spec *unstructured.Unstructured) error {
 }
 
 // DeleteAll removes all tracked `Resources` in the Manifest.
-func (f *Manifest) DeleteAll(opts *metav1.DeleteOptions) error {
+func (f *Manifest) DeleteAll(opts ...ClientOption) error {
 	a := make([]unstructured.Unstructured, len(f.Resources))
 	copy(a, f.Resources)
 	// we want to delete in reverse order
@@ -129,8 +114,8 @@ func (f *Manifest) DeleteAll(opts *metav1.DeleteOptions) error {
 	}
 	for _, spec := range a {
 		if okToDelete(&spec) {
-			if err := f.Delete(&spec, opts); err != nil {
-				log.Error(err, "Delete failed")
+			if err := f.Delete(&spec, opts...); err != nil {
+				f.log.Error(err, "Delete failed")
 			}
 		}
 	}
@@ -139,17 +124,14 @@ func (f *Manifest) DeleteAll(opts *metav1.DeleteOptions) error {
 
 // Delete removes the specified objects, which do not need to be registered as
 // `Resources` in the Manifest.
-func (f *Manifest) Delete(spec *unstructured.Unstructured, opts *metav1.DeleteOptions) error {
-	current, err := f.Get(spec)
+func (f *Manifest) Delete(spec *unstructured.Unstructured, opts ...ClientOption) error {
+	current, err := f.Get(spec, opts...)
 	if current == nil && err == nil {
 		return nil
 	}
-	logResource("Deleting", spec)
-	resource, err := f.ResourceInterface(spec)
-	if err != nil {
-		return err
-	}
-	if err := resource.Delete(spec.GetName(), opts); err != nil {
+	f.logResource("Deleting", spec)
+	options := NewOptions(opts...)
+	if err := f.client.Delete(spec, options.ForDelete()); err != nil {
 		// ignore GC race conditions triggered by owner references
 		if !errors.IsNotFound(err) {
 			return err
@@ -160,12 +142,9 @@ func (f *Manifest) Delete(spec *unstructured.Unstructured, opts *metav1.DeleteOp
 
 // Get collects a full resource body (or `nil`) from a partial resource
 // supplied in `spec`.
-func (f *Manifest) Get(spec *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-	resource, err := f.ResourceInterface(spec)
-	if err != nil {
-		return nil, err
-	}
-	result, err := resource.Get(spec.GetName(), metav1.GetOptions{})
+func (f *Manifest) Get(spec *unstructured.Unstructured, opts ...ClientOption) (*unstructured.Unstructured, error) {
+	options := NewOptions(opts...)
+	result, err := f.client.Get(spec, options.ForGet())
 	if err != nil {
 		result = nil
 		if errors.IsNotFound(err) {
@@ -175,22 +154,9 @@ func (f *Manifest) Get(spec *unstructured.Unstructured) (*unstructured.Unstructu
 	return result, err
 }
 
-// ResourceInterface returns an interface appropriate for the spec
-func (f *Manifest) ResourceInterface(spec *unstructured.Unstructured) (dynamic.ResourceInterface, error) {
-	gvk := spec.GroupVersionKind()
-	mapping, err := f.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
-	if err != nil {
-		return nil, err
-	}
-	if mapping.Scope.Name() == meta.RESTScopeNameRoot {
-		return f.client.Resource(mapping.Resource), nil
-	}
-	return f.client.Resource(mapping.Resource).Namespace(spec.GetNamespace()), nil
-}
-
-func logResource(msg string, spec *unstructured.Unstructured) {
+func (f *Manifest) logResource(msg string, spec *unstructured.Unstructured) {
 	name := fmt.Sprintf("%s/%s", spec.GetNamespace(), spec.GetName())
-	log.Info(msg, "name", name, "type", spec.GroupVersionKind())
+	f.log.Info(msg, "name", name, "type", spec.GroupVersionKind())
 }
 
 func annotate(spec *unstructured.Unstructured, key string, value string) {

--- a/vendor/github.com/manifestival/manifestival/options.go
+++ b/vendor/github.com/manifestival/manifestival/options.go
@@ -1,0 +1,33 @@
+package manifestival
+
+import "github.com/go-logr/logr"
+
+type options struct {
+	recursive bool
+	logger    logr.Logger
+	client    Client
+}
+
+type Option func(*options)
+
+func Recursive(opts *options) {
+	opts.recursive = true
+}
+
+func UseRecursive(v bool) Option {
+	return func(opts *options) {
+		opts.recursive = v
+	}
+}
+
+func UseLogger(log logr.Logger) Option {
+	return func(o *options) {
+		o.logger = log
+	}
+}
+
+func UseClient(client Client) Option {
+	return func(o *options) {
+		o.client = client
+	}
+}

--- a/vendor/github.com/manifestival/manifestival/transform.go
+++ b/vendor/github.com/manifestival/manifestival/transform.go
@@ -35,7 +35,9 @@ func (f *Manifest) Transform(fns ...Transformer) (*Manifest, error) {
 		}
 		results = append(results, *spec)
 	}
-	return &Manifest{Resources: results, client: f.client, mapper: f.mapper}, nil
+	shallow := *f
+	shallow.Resources = results // deep-copied above!
+	return &shallow, nil
 }
 
 // InjectNamespace creates a Transformer which adds a namespace to existing

--- a/vendor/github.com/operator-framework/operator-sdk/pkg/restmapper/dynamicrestmapper.go
+++ b/vendor/github.com/operator-framework/operator-sdk/pkg/restmapper/dynamicrestmapper.go
@@ -23,6 +23,9 @@ import (
 	"k8s.io/client-go/restmapper"
 )
 
+// Deprecated: DynamicRESTMapper exists for historical compatibility
+// and should not be used. See that it was implemented in the controller-runtime.
+// More info: https://github.com/kubernetes-sigs/controller-runtime/pull/554
 type DynamicRESTMapper struct {
 	client   discovery.DiscoveryInterface
 	delegate meta.RESTMapper
@@ -32,6 +35,10 @@ type DynamicRESTMapper struct {
 // types at runtime. This is in contrast to controller-manager's default RESTMapper, which
 // only checks resource types at startup, and so can't handle the case of first creating a
 // CRD and then creating an instance of that CRD.
+//
+// Deprecated: NewDynamicRESTMapper exists for historical compatibility
+// and should not be used. See that it was implemented in the controller-runtime.
+// More info: https://github.com/kubernetes-sigs/controller-runtime/pull/554
 func NewDynamicRESTMapper(cfg *rest.Config) (meta.RESTMapper, error) {
 	client, err := discovery.NewDiscoveryClientForConfig(cfg)
 	if err != nil {
@@ -67,6 +74,9 @@ func (drm *DynamicRESTMapper) reloadOnError(err error) bool {
 	return err == nil
 }
 
+// Deprecated: KindFor exists for historical compatibility
+// and should not be used. See that it was implemented in the controller-runtime.
+// More info: https://github.com/kubernetes-sigs/controller-runtime/pull/554
 func (drm *DynamicRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
 	gvk, err := drm.delegate.KindFor(resource)
 	if drm.reloadOnError(err) {
@@ -75,6 +85,9 @@ func (drm *DynamicRESTMapper) KindFor(resource schema.GroupVersionResource) (sch
 	return gvk, err
 }
 
+// Deprecated: KindsFor exists for historical compatibility
+// and should not be used. See that it was implemented in the controller-runtime.
+// More info: https://github.com/kubernetes-sigs/controller-runtime/pull/554
 func (drm *DynamicRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
 	gvks, err := drm.delegate.KindsFor(resource)
 	if drm.reloadOnError(err) {
@@ -83,6 +96,9 @@ func (drm *DynamicRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]
 	return gvks, err
 }
 
+// Deprecated: ResourceFor exists for historical compatibility
+// and should not be used. See that it was implemented in the controller-runtime.
+// More info: https://github.com/kubernetes-sigs/controller-runtime/pull/554
 func (drm *DynamicRESTMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
 	gvr, err := drm.delegate.ResourceFor(input)
 	if drm.reloadOnError(err) {
@@ -91,6 +107,9 @@ func (drm *DynamicRESTMapper) ResourceFor(input schema.GroupVersionResource) (sc
 	return gvr, err
 }
 
+// Deprecated: ResourcesFor exists for historical compatibility
+// and should not be used. See that it was implemented in the controller-runtime.
+// More info: https://github.com/kubernetes-sigs/controller-runtime/pull/554
 func (drm *DynamicRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
 	gvrs, err := drm.delegate.ResourcesFor(input)
 	if drm.reloadOnError(err) {
@@ -99,6 +118,9 @@ func (drm *DynamicRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([
 	return gvrs, err
 }
 
+// Deprecated: RESTMapping exists for historical compatibility
+// and should not be used. See that it was implemented in the controller-runtime.
+// More info: https://github.com/kubernetes-sigs/controller-runtime/pull/554
 func (drm *DynamicRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
 	m, err := drm.delegate.RESTMapping(gk, versions...)
 	if drm.reloadOnError(err) {
@@ -107,6 +129,9 @@ func (drm *DynamicRESTMapper) RESTMapping(gk schema.GroupKind, versions ...strin
 	return m, err
 }
 
+// Deprecated: RESTMappings exists for historical compatibility
+// and should not be used. See that it was implemented in the controller-runtime.
+// More info: https://github.com/kubernetes-sigs/controller-runtime/pull/554
 func (drm *DynamicRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
 	ms, err := drm.delegate.RESTMappings(gk, versions...)
 	if drm.reloadOnError(err) {
@@ -115,6 +140,9 @@ func (drm *DynamicRESTMapper) RESTMappings(gk schema.GroupKind, versions ...stri
 	return ms, err
 }
 
+// Deprecated: ResourceSingularizer exists for historical compatibility
+// and should not be used. See that it was implemented in the controller-runtime.
+// More info: https://github.com/kubernetes-sigs/controller-runtime/pull/554
 func (drm *DynamicRESTMapper) ResourceSingularizer(resource string) (singular string, err error) {
 	s, err := drm.delegate.ResourceSingularizer(resource)
 	if drm.reloadOnError(err) {


### PR DESCRIPTION
This introduces support for different client implementations, e.g.
client-go and controller-runtime. This repo uses client-go so that
requires a dependency on the repo implementing the client-go
manifestival client.