### PR TITLE
Update to manifestival 0.2.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -382,23 +382,24 @@
   version = "v0.7.0"
 
 [[projects]]
-  digest = "1:884250c3c0343f0c1533b7d9251fdb183a6ece6e896b69de6b254c60389c5bc9"
+  digest = "1:dd895309ca7dbb6f5ef345c76f4e1dfe23accbcdaacde852bfcdabba1f754e5b"
   name = "github.com/manifestival/client-go-client"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "c29246a03e39f027084d68a6be8bbb7357095741"
-  version = "v0.1.0"
+  revision = "c2f50cd3164d79466429c02e5599dfe61a40cc8e"
+  version = "v0.2.0"
 
 [[projects]]
-  digest = "1:b9a54a63e2936b1d3dac7d39d0c11c092fa13bb34c3eb8a307317da5766941ee"
+  digest = "1:a0cb66a2605af422373e94b7ce8f9904cf22616e16b74e8601cc529808ffc5a1"
   name = "github.com/manifestival/manifestival"
   packages = [
     ".",
     "patch",
+    "sources",
   ]
   pruneopts = "NUT"
-  revision = "f5dd205675d3301a65eeb90aa4c7f793b8c0897f"
-  version = "v0.1.0"
+  revision = "062c519a505b425bf0990e7f78e06568b2756b89"
+  version = "v0.2.0"
 
 [[projects]]
   digest = "1:5985ef4caf91ece5d54817c11ea25f182697534f8ae6521eadcd628c142ac4b6"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -50,7 +50,7 @@ required = [
 
 [[constraint]]
   name = "github.com/manifestival/manifestival"
-  version = "0.1.0"
+  version = "0.2.0"
 
 [[override]]
   name = "knative.dev/pkg"

--- a/test/resources/verify.go
+++ b/test/resources/verify.go
@@ -209,7 +209,7 @@ func KSOperatorCRDelete(t *testing.T, clients *test.Clients, names test.Resource
 	if err := verifyNoKSOperatorCR(clients); err != nil {
 		t.Fatal(err)
 	}
-	for _, u := range m.Resources {
+	for _, u := range m.Resources() {
 		if u.GetKind() == "Namespace" {
 			// The namespace should be skipped, because when the CR is removed, the Manifest to be removed has
 			// been modified, since the namespace can be injected.

--- a/vendor/github.com/manifestival/manifestival/filter.go
+++ b/vendor/github.com/manifestival/manifestival/filter.go
@@ -1,0 +1,76 @@
+package manifestival
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Predicate returns true if u should be included in result
+type Predicate func(u *unstructured.Unstructured) bool
+
+// Filter returns a Manifest containing only the resources for which
+// *all* Predicates return true. Any changes callers make to the
+// resources passed to their Predicate[s] will only be reflected in
+// the returned Manifest.
+func (m Manifest) Filter(fns ...Predicate) Manifest {
+	result := m
+	result.resources = []unstructured.Unstructured{}
+NEXT_RESOURCE:
+	for _, spec := range m.Resources() {
+		for _, pred := range fns {
+			if pred != nil {
+				if !pred(&spec) {
+					continue NEXT_RESOURCE
+				}
+			}
+		}
+		result.resources = append(result.resources, spec)
+	}
+	return result
+}
+
+// JustCRDs returns only CustomResourceDefinitions
+var JustCRDs = ByKind("CustomResourceDefinition")
+
+// NotCRDs returns no CustomResourceDefinitions
+var NotCRDs = Complement(JustCRDs)
+
+// ByName returns resources with a specifc name
+func ByName(name string) Predicate {
+	return func(u *unstructured.Unstructured) bool {
+		return u.GetName() == name
+	}
+}
+
+// ByKind returns resources matching a particular kind
+func ByKind(kind string) Predicate {
+	return func(u *unstructured.Unstructured) bool {
+		return u.GetKind() == kind
+	}
+}
+
+// ByLabel returns resources that contain a particular label and
+// value. A value of "" denotes *ANY* value
+func ByLabel(label, value string) Predicate {
+	return func(u *unstructured.Unstructured) bool {
+		v, ok := u.GetLabels()[label]
+		if value == "" {
+			return ok
+		}
+		return v == value
+	}
+}
+
+// ByGVK returns resources of a particular GroupVersionKind
+func ByGVK(gvk schema.GroupVersionKind) Predicate {
+	return func(u *unstructured.Unstructured) bool {
+		return u.GroupVersionKind() == gvk
+	}
+}
+
+// Complement returns what another Predicate wouldn't
+func Complement(p Predicate) Predicate {
+	return func(u *unstructured.Unstructured) bool {
+		return !p(u)
+	}
+}

--- a/vendor/github.com/manifestival/manifestival/manifestival.go
+++ b/vendor/github.com/manifestival/manifestival/manifestival.go
@@ -16,73 +16,74 @@ import (
 // apiserver.
 type Manifestival interface {
 	// Either updates or creates all resources in the manifest
-	ApplyAll(opts ...ClientOption) error
-	// Updates or creates a particular resource
-	Apply(spec *unstructured.Unstructured, opts ...ClientOption) error
+	Apply(opts ...ApplyOption) error
 	// Deletes all resources in the manifest
-	DeleteAll(opts ...ClientOption) error
-	// Deletes a particular resource
-	Delete(spec *unstructured.Unstructured, opts ...ClientOption) error
-	// Returns a copy of the resource from the api server, nil if not found
-	Get(spec *unstructured.Unstructured, opts ...ClientOption) (*unstructured.Unstructured, error)
+	Delete(opts ...DeleteOption) error
 	// Transforms the resources within a Manifest
-	Transform(fns ...Transformer) (*Manifest, error)
+	Transform(fns ...Transformer) (Manifest, error)
+	// Filters resources in a Manifest; Predicates are AND'd
+	Filter(fns ...Predicate) Manifest
 }
 
 // Manifest tracks a set of concrete resources which should be managed as a
 // group using a Kubernetes client provided by `NewManifest`.
 type Manifest struct {
-	Resources []unstructured.Unstructured
-	client    Client
+	resources []unstructured.Unstructured
+	Client    Client
 	log       logr.Logger
 }
 
 var _ Manifestival = &Manifest{}
 
-// NewManifest creates a Manifest from a comma-separated set of yaml files or
-// directories (and subdirectories if the `recursive` option is set). The
-// Manifest will be evaluated using the supplied `config` against a particular
-// Kubernetes apiserver.
+// NewManifest creates a Manifest from a comma-separated set of yaml
+// files, directories, or URLs. The Manifest's client and logger may
+// be optionally provided.
 func NewManifest(pathname string, opts ...Option) (Manifest, error) {
-	o := &options{}
-	for _, opt := range opts {
-		opt(o)
-	}
-	log := o.logger
-	if log == nil {
-		log = testing.NullLogger{}
-	}
-	log.Info("Reading manifest", "name", pathname)
-	resources, err := Parse(pathname, o.recursive)
-	if err != nil {
-		return Manifest{}, err
-	}
-	return Manifest{Resources: resources, client: o.client, log: log}, nil
+	return ManifestFrom(Path(pathname), opts...)
 }
 
-// ApplyAll updates or creates all resources in the manifest.
-func (f *Manifest) ApplyAll(opts ...ClientOption) error {
-	for _, spec := range f.Resources {
-		if err := f.Apply(&spec, opts...); err != nil {
+// ManifestFrom creates a Manifest from any Source
+func ManifestFrom(src Source, opts ...Option) (m Manifest, err error) {
+	m = Manifest{log: testing.NullLogger{}}
+	for _, opt := range opts {
+		opt(&m)
+	}
+	m.log.Info("Parsing manifest")
+	m.resources, err = src.Parse()
+	return
+}
+
+// Resources returns a deep copy of the manifest resources
+func (m Manifest) Resources() []unstructured.Unstructured {
+	result := make([]unstructured.Unstructured, len(m.resources))
+	for i, v := range m.resources {
+		result[i] = *v.DeepCopy()
+	}
+	return result
+}
+
+// Apply updates or creates all resources in the manifest.
+func (m Manifest) Apply(opts ...ApplyOption) error {
+	for _, spec := range m.resources {
+		if err := m.apply(&spec, opts...); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// Apply updates or creates a particular resource, which does not need to be
+// apply updates or creates a particular resource, which does not need to be
 // part of `Resources`, and will not be tracked.
-func (f *Manifest) Apply(spec *unstructured.Unstructured, opts ...ClientOption) error {
-	current, err := f.Get(spec, opts...)
+func (m Manifest) apply(spec *unstructured.Unstructured, opts ...ApplyOption) error {
+	current, err := m.get(spec)
 	if err != nil {
 		return err
 	}
-	options := NewOptions(opts...)
 	if current == nil {
-		f.logResource("Creating", spec)
+		m.logResource("Creating", spec)
 		annotate(spec, v1.LastAppliedConfigAnnotation, patch.MakeLastAppliedConfig(spec))
 		annotate(spec, "manifestival", resourceCreated)
-		if err = f.client.Create(spec.DeepCopy(), options.ForCreate()); err != nil {
+		if err = m.Client.Create(spec.DeepCopy(), opts...); err != nil {
 			return err
 		}
 	} else {
@@ -91,12 +92,12 @@ func (f *Manifest) Apply(spec *unstructured.Unstructured, opts ...ClientOption) 
 			return err
 		}
 		if patch.IsRequired() {
-			f.log.Info("Merging", "diff", patch)
+			m.log.Info("Merging", "diff", patch)
 			if err := patch.Merge(current); err != nil {
 				return err
 			}
-			f.logResource("Updating", current)
-			if err = f.client.Update(current, options.ForUpdate()); err != nil {
+			m.logResource("Updating", current)
+			if err = m.Client.Update(current, opts...); err != nil {
 				return err
 			}
 		}
@@ -104,47 +105,39 @@ func (f *Manifest) Apply(spec *unstructured.Unstructured, opts ...ClientOption) 
 	return nil
 }
 
-// DeleteAll removes all tracked `Resources` in the Manifest.
-func (f *Manifest) DeleteAll(opts ...ClientOption) error {
-	a := make([]unstructured.Unstructured, len(f.Resources))
-	copy(a, f.Resources)
+// Delete removes all tracked `Resources` in the Manifest.
+func (m Manifest) Delete(opts ...DeleteOption) error {
+	a := make([]unstructured.Unstructured, len(m.resources))
+	copy(a, m.resources) // shallow copy is fine
 	// we want to delete in reverse order
 	for left, right := 0, len(a)-1; left < right; left, right = left+1, right-1 {
 		a[left], a[right] = a[right], a[left]
 	}
 	for _, spec := range a {
 		if okToDelete(&spec) {
-			if err := f.Delete(&spec, opts...); err != nil {
-				f.log.Error(err, "Delete failed")
+			if err := m.delete(&spec, opts...); err != nil {
+				m.log.Error(err, "Delete failed")
 			}
 		}
 	}
 	return nil
 }
 
-// Delete removes the specified objects, which do not need to be registered as
+// delete removes the specified objects, which do not need to be registered as
 // `Resources` in the Manifest.
-func (f *Manifest) Delete(spec *unstructured.Unstructured, opts ...ClientOption) error {
-	current, err := f.Get(spec, opts...)
+func (m Manifest) delete(spec *unstructured.Unstructured, opts ...DeleteOption) error {
+	current, err := m.get(spec)
 	if current == nil && err == nil {
 		return nil
 	}
-	f.logResource("Deleting", spec)
-	options := NewOptions(opts...)
-	if err := f.client.Delete(spec, options.ForDelete()); err != nil {
-		// ignore GC race conditions triggered by owner references
-		if !errors.IsNotFound(err) {
-			return err
-		}
-	}
-	return nil
+	m.logResource("Deleting", spec)
+	return m.Client.Delete(spec, opts...)
 }
 
-// Get collects a full resource body (or `nil`) from a partial resource
+// get collects a full resource body (or `nil`) from a partial resource
 // supplied in `spec`.
-func (f *Manifest) Get(spec *unstructured.Unstructured, opts ...ClientOption) (*unstructured.Unstructured, error) {
-	options := NewOptions(opts...)
-	result, err := f.client.Get(spec, options.ForGet())
+func (m Manifest) get(spec *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	result, err := m.Client.Get(spec)
 	if err != nil {
 		result = nil
 		if errors.IsNotFound(err) {
@@ -154,9 +147,9 @@ func (f *Manifest) Get(spec *unstructured.Unstructured, opts ...ClientOption) (*
 	return result, err
 }
 
-func (f *Manifest) logResource(msg string, spec *unstructured.Unstructured) {
+func (m Manifest) logResource(msg string, spec *unstructured.Unstructured) {
 	name := fmt.Sprintf("%s/%s", spec.GetNamespace(), spec.GetName())
-	f.log.Info(msg, "name", name, "type", spec.GroupVersionKind())
+	m.log.Info(msg, "name", name, "type", spec.GroupVersionKind())
 }
 
 func annotate(spec *unstructured.Unstructured, key string, value string) {

--- a/vendor/github.com/manifestival/manifestival/options.go
+++ b/vendor/github.com/manifestival/manifestival/options.go
@@ -2,32 +2,16 @@ package manifestival
 
 import "github.com/go-logr/logr"
 
-type options struct {
-	recursive bool
-	logger    logr.Logger
-	client    Client
-}
-
-type Option func(*options)
-
-func Recursive(opts *options) {
-	opts.recursive = true
-}
-
-func UseRecursive(v bool) Option {
-	return func(opts *options) {
-		opts.recursive = v
-	}
-}
+type Option func(*Manifest)
 
 func UseLogger(log logr.Logger) Option {
-	return func(o *options) {
-		o.logger = log
+	return func(m *Manifest) {
+		m.log = log
 	}
 }
 
 func UseClient(client Client) Option {
-	return func(o *options) {
-		o.client = client
+	return func(m *Manifest) {
+		m.Client = client
 	}
 }

--- a/vendor/github.com/manifestival/manifestival/source.go
+++ b/vendor/github.com/manifestival/manifestival/source.go
@@ -1,0 +1,46 @@
+package manifestival
+
+import (
+	"io"
+
+	"github.com/manifestival/manifestival/sources"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type Source interface {
+	Parse() ([]unstructured.Unstructured, error)
+}
+
+// Implementations
+var _ Source = Path("")
+var _ Source = Recursive("")
+var _ Source = Slice([]unstructured.Unstructured{})
+var _ Source = reader{} // see Reader(io.Reader)
+
+type Path string
+type Recursive string
+type Slice []unstructured.Unstructured
+
+func Reader(r io.Reader) Source {
+	return reader{r}
+}
+
+func (p Path) Parse() ([]unstructured.Unstructured, error) {
+	return sources.Parse(string(p), false)
+}
+
+func (r Recursive) Parse() ([]unstructured.Unstructured, error) {
+	return sources.Parse(string(r), true)
+}
+
+func (s Slice) Parse() ([]unstructured.Unstructured, error) {
+	return []unstructured.Unstructured(s), nil
+}
+
+func (r reader) Parse() ([]unstructured.Unstructured, error) {
+	return sources.Decode(r.real)
+}
+
+type reader struct {
+	real io.Reader
+}

--- a/vendor/github.com/manifestival/manifestival/sources/path.go
+++ b/vendor/github.com/manifestival/manifestival/sources/path.go
@@ -1,7 +1,6 @@
-package manifestival
+package sources
 
 import (
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -10,7 +9,6 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 // Parse parses YAML files into Unstructured objects.
@@ -65,7 +63,7 @@ func readFile(pathname string) ([]unstructured.Unstructured, error) {
 	}
 	defer file.Close()
 
-	return decode(file)
+	return Decode(file)
 }
 
 // readDir parses all files in a single directory and it's descendant directories
@@ -109,29 +107,7 @@ func readURL(url string) ([]unstructured.Unstructured, error) {
 	}
 	defer resp.Body.Close()
 
-	return decode(resp.Body)
-}
-
-// decode consumes the given reader and parses its contents as YAML.
-func decode(reader io.Reader) ([]unstructured.Unstructured, error) {
-	decoder := yaml.NewYAMLToJSONDecoder(reader)
-	objs := []unstructured.Unstructured{}
-	var err error
-	for {
-		out := unstructured.Unstructured{}
-		err = decoder.Decode(&out)
-		if err == io.EOF {
-			break
-		}
-		if err != nil || len(out.Object) == 0 {
-			continue
-		}
-		objs = append(objs, out)
-	}
-	if err != io.EOF {
-		return nil, err
-	}
-	return objs, nil
+	return Decode(resp.Body)
 }
 
 // isURL checks whether or not the given path parses as a URL.

--- a/vendor/github.com/manifestival/manifestival/sources/yaml.go
+++ b/vendor/github.com/manifestival/manifestival/sources/yaml.go
@@ -1,0 +1,30 @@
+package sources
+
+import (
+	"io"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// decode consumes the given reader and parses its contents as YAML.
+func Decode(reader io.Reader) ([]unstructured.Unstructured, error) {
+	decoder := yaml.NewYAMLToJSONDecoder(reader)
+	objs := []unstructured.Unstructured{}
+	var err error
+	for {
+		out := unstructured.Unstructured{}
+		err = decoder.Decode(&out)
+		if err == io.EOF {
+			break
+		}
+		if err != nil || len(out.Object) == 0 {
+			continue
+		}
+		objs = append(objs, out)
+	}
+	if err != io.EOF {
+		return nil, err
+	}
+	return objs, nil
+}

--- a/vendor/github.com/manifestival/manifestival/transform.go
+++ b/vendor/github.com/manifestival/manifestival/transform.go
@@ -21,23 +21,20 @@ type Owner interface {
 // Transform applies an ordered set of Transformer functions to the
 // `Resources` in this Manifest.  If an error occurs, no resources are
 // transformed.
-func (f *Manifest) Transform(fns ...Transformer) (*Manifest, error) {
-	var results []unstructured.Unstructured
-	for i := 0; i < len(f.Resources); i++ {
-		spec := f.Resources[i].DeepCopy()
+func (m Manifest) Transform(fns ...Transformer) (Manifest, error) {
+	result := m
+	result.resources = m.Resources() // deep copies
+	for _, spec := range result.resources {
 		for _, transform := range fns {
 			if transform != nil {
-				err := transform(spec)
+				err := transform(&spec)
 				if err != nil {
-					return nil, err
+					return Manifest{}, err
 				}
 			}
 		}
-		results = append(results, *spec)
 	}
-	shallow := *f
-	shallow.Resources = results // deep-copied above!
-	return &shallow, nil
+	return result, nil
 }
 
 // InjectNamespace creates a Transformer which adds a namespace to existing

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -25,20 +25,17 @@ import (
 
 func TestManifestVersionSame(t *testing.T) {
 	_, b, _, _ := runtime.Caller(0)
-	resources, err := mf.Parse(filepath.Join(filepath.Dir(b)+"/..", "cmd/manager/kodata/knative-serving/"), false)
+	manifest, err := mf.NewManifest(filepath.Join(filepath.Dir(b)+"/..", "cmd/manager/kodata/knative-serving/"))
 	if err != nil {
 		t.Fatal("Failed to load manifest", err)
 	}
 
 	// example: v0.10.1
 	expectedLabelValue := "v" + Version
+	label := "serving.knative.dev/release"
 
-	for _, resource := range resources {
-		v, found := resource.GetLabels()["serving.knative.dev/release"]
-		if !found {
-			// label is missing for this resource. we cannot do the check.
-			continue
-		}
+	for _, resource := range manifest.Filter(mf.ByLabel(label, "")).Resources() {
+		v := resource.GetLabels()[label]
 		if v != expectedLabelValue {
 			t.Errorf("Version info in manifest and operator don't match. got: %v, want: %v. Resource GVK: %v, Resource name: %v", v, expectedLabelValue,
 				resource.GroupVersionKind(), resource.GetName())


### PR DESCRIPTION
This brings in several API enhancements and bug fixes. In particular,
the Filter function makes it easy to prevent the deletion of CRD
resources when the KS CR is deleted. We can make that change in a
separate PR once this one's merged.