### PR TITLE
No longer deleting CRD's when KnativeServing is deleted

### DIFF
--- a/pkg/reconciler/knativeserving/knativeserving_controller.go
+++ b/pkg/reconciler/knativeserving/knativeserving_controller.go
@@ -247,7 +247,7 @@ func (r *Reconciler) delete(instance *servingv1alpha1.KnativeServing) error {
 		return nil
 	}
 	if len(r.servings) == 0 {
-		if err := r.config.Delete(); err != nil {
+		if err := r.config.Filter(mf.NotCRDs).Delete(); err != nil {
 			return err
 		}
 	}

--- a/test/resources/verify.go
+++ b/test/resources/verify.go
@@ -20,7 +20,8 @@ import (
 	"runtime"
 	"testing"
 
-	mf "github.com/manifestival/client-go-client"
+	mfc "github.com/manifestival/client-go-client"
+	mf "github.com/manifestival/manifestival"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -201,20 +202,27 @@ func KSOperatorCRDelete(t *testing.T, clients *test.Clients, names test.Resource
 		t.Fatal("Timed out waiting on KnativeServing to delete", err)
 	}
 	_, b, _, _ := runtime.Caller(0)
-	m, err := mf.NewManifest(filepath.Join((filepath.Dir(b)+"/.."), "config/"), clients.Config)
+	m, err := mfc.NewManifest(filepath.Join((filepath.Dir(b)+"/.."), "config/"), clients.Config)
 	if err != nil {
 		t.Fatal("Failed to load manifest", err)
 	}
 	if err := verifyNoKSOperatorCR(clients); err != nil {
 		t.Fatal(err)
 	}
-	for _, u := range m.Resources() {
-		if u.GetKind() == "Namespace" || u.GetKind() == "CustomResourceDefinition" {
-			// These won't be deleted
-			continue
-		}
+
+	// TODO: pred := mf.Any(mf.CRDs, mf.ByKind("Namespace"))
+	// Loop through both pred and mf.None(pred)
+
+	// verify all but the CRD's and the Namespace are gone
+	for _, u := range m.Filter(mf.NotCRDs, mf.Complement(mf.ByKind("Namespace"))).Resources() {
 		if _, err := m.Client.Get(&u); !apierrs.IsNotFound(err) {
 			t.Fatalf("The %s %s failed to be deleted: %v", u.GetKind(), u.GetName(), err)
+		}
+	}
+	// verify all the CRD's remain
+	for _, u := range m.Filter(mf.JustCRDs).Resources() {
+		if _, err := m.Client.Get(&u); apierrs.IsNotFound(err) {
+			t.Fatalf("The %s CRD was deleted", u.GetName())
 		}
 	}
 }


### PR DESCRIPTION
Fixes #307 

## Proposed Changes

* No longer deleting CRD's

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The operator will no longer remove `*.knative.dev` CRD's when uninstalling knative-serving.
```
