### PR TITLE
Remove myself from approvers/reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,6 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- bbrowning
 - houshengbo
 - jcrossley3
 - k4leung4
@@ -10,7 +9,6 @@ approvers:
 - mattmoor       # TOC member as backup
 
 reviewers:
-- bbrowning
 - houshengbo
 - jcrossley3
 - k4leung4


### PR DESCRIPTION
Feel free to ping me directly if my review is desired on a PR. But, removing myself from OWNERS so the bot can make better auto-assignment of reviewers and approvers.
