### PR TITLE
Filter manifest to install/uninstall extensions such as serving-cert-manager, ns-cert and networking-istio

### DIFF
--- a/cmd/manager/kodata/knative-serving/0.13.0.yaml
+++ b/cmd/manager/kodata/knative-serving/0.13.0.yaml
@@ -2751,3 +2751,260 @@ spec:
 # profiling because it opts out of the mesh (see annotation above).
 
 ---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  # These are the permissions needed by the `cert-manager` `Certificate` implementation.
+  name: knative-serving-certmanager
+  labels:
+    serving.knative.dev/release: "v0.13.0"
+    serving.knative.dev/controller: "true"
+    networking.knative.dev/certificate-provider: cert-manager
+rules:
+- apiGroups: ["cert-manager.io"]
+  resources: ["certificates", "clusterissuers"]
+  verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+- apiGroups: ["acme.cert-manager.io"]
+  resources: ["challenges"]
+  verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-certmanager
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.13.0"
+    networking.knative.dev/certificate-provider: cert-manager
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this block and unindented to actually change the configuration.
+
+    # issuerRef is a reference to the issuer for this certificate.
+    # IssuerRef should be either `ClusterIssuer` or `Issuer`.
+    # Please refer `IssuerRef` in https://github.com/jetstack/cert-manager/blob/master/pkg/apis/certmanager/v1alpha1/types_certificate.go
+    # for more details about IssuerRef configuration.
+    issuerRef: |
+      kind: ClusterIssuer
+      name: letsencrypt-issuer
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: networking-certmanager
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.13.0"
+    networking.knative.dev/certificate-provider: cert-manager
+spec:
+  selector:
+    matchLabels:
+      app: networking-certmanager
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: networking-certmanager
+        serving.knative.dev/release: "v0.13.0"
+    spec:
+      serviceAccountName: controller
+      containers:
+      - name: networking-certmanager
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/networking/certmanager@sha256:ee7b0e8cbe56b50129c71cd8d7b37098d891139ffc8d3c35da5f4417b5ae1b60
+        resources:
+          requests:
+            cpu: 30m
+            memory: 40Mi
+          limits:
+            cpu: 300m
+            memory: 400Mi
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
+          name: METRICS_DOMAIN
+          value: knative.dev/serving
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: networking-certmanager
+    serving.knative.dev/release: "v0.13.0"
+    networking.knative.dev/certificate-provider: cert-manager
+  name: networking-certmanager
+  namespace: knative-serving
+spec:
+  ports:
+  - # Define metrics and profiling for them to be accessible within service meshes.
+    name: http-metrics
+    port: 9090
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    targetPort: 8008
+  selector:
+    app: networking-certmanager
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: networking-ns-cert
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.13.0"
+    networking.knative.dev/wildcard-certificate-provider: nscert
+spec:
+  selector:
+    matchLabels:
+      app: networking-ns-cert
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: networking-ns-cert
+        serving.knative.dev/release: "v0.13.0"
+    spec:
+      serviceAccountName: controller
+      containers:
+      - name: networking-nscert
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/networking/nscert@sha256:a5fc8253d8021b3f2d0a1e95ca7437a3781c56706e230f442f006b4b48c4dc0e
+        resources:
+          requests:
+            cpu: 30m
+            memory: 40Mi
+          limits:
+            cpu: 300m
+            memory: 400Mi
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
+          name: METRICS_DOMAIN
+          value: knative.dev/serving
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: networking-ns-cert
+    serving.knative.dev/release: "v0.13.0"
+    networking.knative.dev/wildcard-certificate-provider: nscert
+  name: networking-ns-cert
+  namespace: knative-serving
+spec:
+  ports:
+  - # Define metrics and profiling for them to be accessible within service meshes.
+    name: http-metrics
+    port: 9090
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    targetPort: 8008
+  selector:
+    app: networking-ns-cert
+
+---

--- a/pkg/reconciler/knativeserving/knativeserving_controller.go
+++ b/pkg/reconciler/knativeserving/knativeserving_controller.go
@@ -195,8 +195,6 @@ func (r *Reconciler) filter(manifest *mf.Manifest, instance *servingv1alpha1.Kna
 	if len(labels) == 0 {
 		return *manifest, nil
 	}
-	// TODO: manifestival's Delete() prints error logs but never returns error actually, so this IsNoMatchError does not make sense.
-	// But leave this code here to show we cannot control "no matches for kind" erorr atm.
 	if err := manifest.Filter(byLabels(labels)).Filter(mf.NotCRDs).Delete(); err != nil && !meta.IsNoMatchError(err) {
 		return *manifest, err
 	}

--- a/pkg/reconciler/knativeserving/knativeserving_controller.go
+++ b/pkg/reconciler/knativeserving/knativeserving_controller.go
@@ -273,6 +273,9 @@ func isAutoTLSEnabled(manifest *mf.Manifest, instance *servingv1alpha1.KnativeSe
 
 // isIngressIstio returns true when ingress.class is istio.ingress.networking.knative.dev or default(empty).
 func isIngressIstio(manifest *mf.Manifest, instance *servingv1alpha1.KnativeServing) bool {
+	if _, ok := instance.Spec.Config["network"]; !ok {
+		return true
+	}
 	if ingress := instance.Spec.Config["network"]["ingress.class"]; ingress == "istio.ingress.networking.knative.dev" || ingress == "" {
 		return true
 	}

--- a/pkg/reconciler/knativeserving/knativeserving_controller.go
+++ b/pkg/reconciler/knativeserving/knativeserving_controller.go
@@ -50,7 +50,7 @@ const (
 
 var (
 	istioLabels   = map[string]string{"networking.knative.dev/ingress-provider": "istio"}
-	autoTlsLabels = map[string]string{"networking.knative.dev/certificate-provider": "cert-manager", "networking.knative.dev/wildcard-certificate-provider": "nscert"}
+	autoTLSLabels = map[string]string{"networking.knative.dev/certificate-provider": "cert-manager", "networking.knative.dev/wildcard-certificate-provider": "nscert"}
 )
 
 // Reconciler implements controller.Reconciler for Knativeserving resources.
@@ -188,7 +188,7 @@ func (r *Reconciler) filter(manifest *mf.Manifest, instance *servingv1alpha1.Kna
 	}
 	if !isAutoTLSEnabled(manifest, instance) {
 		r.Logger.Debug("Removing autoTLS extention resources")
-		for k, v := range autoTlsLabels {
+		for k, v := range autoTLSLabels {
 			labels[k] = v
 		}
 	}


### PR DESCRIPTION
This patch supports filter function to install/uninstall extensions
such as serving-cert-manager, networking-ns-cert and istio
ingress by the configuration. It solves following two problems.

#### problem 1

When `autoTLS` is enabled in config-network, we need
[namespace-wildcard-certs](https://github.com/knative/serving/tree/master/config/namespace-wildcard-certs) and [cert-manager](https://github.com/knative/serving/tree/master/config/cert-manager)
to be deployed. However current operator does not install them.

#### problem 2

When we want to change `ingress.class` to antoher Ingress solution
instead of Istio, current operator always deploys networking-istio and 
istio gateways.

To solve them, this patch filters manifest to install/uninstall
by the configuration.

e.g - when `autoTLS=Enabled`  `ingress.calss=kourier` is configured w/ this PR

```
$ kubectl get pod  -n knative-serving
NAME                                      READY   STATUS    RESTARTS   AGE
activator-869f6d4f9f-ll75v                1/1     Running   2          87m
autoscaler-78994c9fdf-c6kmn               1/1     Running   2          87m
autoscaler-hpa-66bcf9cdc-sxt72            1/1     Running   0          87m
controller-b94c5b667-97wkl                1/1     Running   2          87m
networking-certmanager-5bfcf45d79-kc958   1/1     Running   0          21m
networking-ns-cert-5447795455-wx9pj       1/1     Running   0          21m
webhook-7cdb467d79-4jrfq                  1/1     Running   2          87m
```

**Release Note**

```release-note
serving-cert-manager and networking-ns-cert are deployed when autoTLS is Enabled.
networking-istio is not deployed when ingress.class is not Istio.
```

/lint