### PR TITLE
Quick fix for upgrade prow job

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -68,7 +68,6 @@ function donwload_knative_serving() {
     git fetch origin ${branch}:${branch}
     git checkout ${branch}
   fi
-  LATEST_SERVING_RELEASE_VERSION=$(git tag | sort -V | tail -1)
   cd ${OPERATOR_DIR}
 }
 
@@ -77,7 +76,7 @@ function install_istio() {
   local base_url="https://raw.githubusercontent.com/knative/serving/${LATEST_SERVING_RELEASE_VERSION}"
   local istio_version="istio-${ISTIO_VERSION}"
   if [[ ${istio_version} == *-latest ]] ; then
-    istio_version=$(curl https://raw.githubusercontent.com/knative/serving/v0.13.0/third_party/${istio_version})
+    istio_version=$(curl https://raw.githubusercontent.com/knative/serving/${LATEST_SERVING_RELEASE_VERSION}/third_party/${istio_version})
   fi
   INSTALL_ISTIO_CRD_YAML="${base_url}/$(istio_crds_yaml $istio_version)"
   INSTALL_ISTIO_YAML="${base_url}/$(istio_yaml $istio_version $ISTIO_MESH)"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* Pin the upgrade to test against 0.13.0 manifest of serving. Issue with
the latest manifest will be resolved for next release. There is no need to call
`generate_latest_serving_manifest`.
* Replace the key word `all` with `deployment, pod, service, apiservice`.
* I will implement a better way to get the value for `LATEST_SERVING_RELEASE_VERSION` automatically, so far pin it to v0.12.1.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
