### PR TITLE
Remove the deprecated short name from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,12 @@ The following are all equivalent:
 ```
 kubectl get knativeservings.operator.knative.dev -oyaml
 kubectl get knativeserving -oyaml
-kubectl get ks -oyaml
 ```
 
 To uninstall Knative Serving, simply delete the `KnativeServing` resource.
 
 ```
-kubectl delete ks --all
+kubectl delete knativeserving --all
 ```
 
 ## Development


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* By https://github.com/knative/serving-operator/pull/250, short name **ks** for the Knative Serving Operator CRD was removed from code. This PR is removing remaining **ks** in README.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Remove the deprecated short name from README.
```
