### PR TITLE
Update the upgrade to check upgrading from 0.13.0

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -19,14 +19,19 @@ source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/e2e-tests.sh
 
 # Latest serving operator release.
 readonly LATEST_SERVING_OPERATOR_RELEASE_VERSION=$(git tag | sort -V | tail -1)
-# Latest serving release. This can be different from LATEST_SERVING_OPERATOR_RELEASE_VERSION.
+# Latest serving release, installed by the operator at LATEST_SERVING_OPERATOR_RELEASE_VERSION. This can be
+# different from LATEST_SERVING_OPERATOR_RELEASE_VERSION.
 LATEST_SERVING_RELEASE_VERSION="v0.13.0"
+# This is the branch name of serving repo, where we run the upgrade tests.
+SERVING_REPO_BRANCH=${PULL_BASE_REF}
 # Istio version we test with
 readonly ISTIO_VERSION="1.4-latest"
 # Test without Istio mesh enabled
 readonly ISTIO_MESH=0
 # Namespace used for tests
 readonly TEST_NAMESPACE="knative-serving"
+# Boolean used to indicate whether to generate serving YAML based on the latest code in the branch SERVING_REPO_BRANCH.
+GENERATE_SERVING_YAML=1
 
 OPERATOR_DIR=$(dirname $0)/..
 KNATIVE_SERVING_DIR=${OPERATOR_DIR}/..

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -20,7 +20,7 @@ source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/e2e-tests.sh
 # Latest serving operator release.
 readonly LATEST_SERVING_OPERATOR_RELEASE_VERSION=$(git tag | sort -V | tail -1)
 # Latest serving release. This can be different from LATEST_SERVING_OPERATOR_RELEASE_VERSION.
-LATEST_SERVING_RELEASE_VERSION="v0.12.1"
+LATEST_SERVING_RELEASE_VERSION="v0.13.0"
 # Istio version we test with
 readonly ISTIO_VERSION="1.4-latest"
 # Test without Istio mesh enabled

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -39,7 +39,7 @@ function install_previous_operator_release() {
   wget "${full_url}" -O "${release_yaml}" \
       || fail_test "Unable to download latest Knative Serving Operator release."
 
-  donwload_knative_serving release-0.13
+  donwload_knative_serving ${PULL_BASE_REF}
   install_istio || fail_test "Istio installation failed"
   install_previous_serving_release
 }

--- a/test/upgrade/servingoperator_postupgrade_test.go
+++ b/test/upgrade/servingoperator_postupgrade_test.go
@@ -45,7 +45,7 @@ func TestKnativeServingPostUpgrade(t *testing.T) {
 	t.Run("verify resources", func(t *testing.T) {
 		// TODO: We only verify the deployment, but we need to add other resources as well, like ServiceAccount, ClusterRoleBinding, etc.
 		expectedDeployments := []string{"networking-istio", "webhook", "controller", "activator", "autoscaler-hpa",
-			"autoscaler"}
+			"autoscaler", "istio-webhook"}
 		resources.AssertKSOperatorDeploymentStatus(t, clients, names.Namespace, expectedDeployments)
 		resources.AssertKSOperatorCRReadyStatus(t, clients, names)
 	})


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* After 0.13 release is cut-off, we need to change the upgrade prow job, by setting the previous
release to 0.13, and upgrading to the latest serving YAML.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
