### PR TITLE
Delete (Cluster)Role(Bindings) as a final cleanup step.

### DIFF
--- a/pkg/reconciler/knativeserving/knativeserving_controller.go
+++ b/pkg/reconciler/knativeserving/knativeserving_controller.go
@@ -251,7 +251,7 @@ func (r *Reconciler) delete(instance *servingv1alpha1.KnativeServing) error {
 		if err := r.config.Filter(mf.ByKind("Deployment")).Delete(); err != nil {
 			return err
 		}
-		if err := r.config.Filter(mf.All(mf.NoCRDs, mf.None(RBAC))).Delete(); err != nil {
+		if err := r.config.Filter(mf.NoCRDs, mf.None(RBAC)).Delete(); err != nil {
 			return err
 		}
 		// Delete Roles last, as they may be useful for human operators to clean up.

--- a/pkg/reconciler/knativeserving/knativeserving_controller.go
+++ b/pkg/reconciler/knativeserving/knativeserving_controller.go
@@ -255,7 +255,7 @@ func (r *Reconciler) delete(instance *servingv1alpha1.KnativeServing) error {
 			return err
 		}
 		// Delete Roles last, as they may be granting us permissions that are necessary.
-	        if err := r.config.Filter(RbacResources).Delete(); err != nil {
+		if err := r.config.Filter(RbacResources).Delete(); err != nil {
 			return err
 		}
 	}

--- a/pkg/reconciler/knativeserving/knativeserving_controller.go
+++ b/pkg/reconciler/knativeserving/knativeserving_controller.go
@@ -246,11 +246,16 @@ func (r *Reconciler) delete(instance *servingv1alpha1.KnativeServing) error {
 	if len(instance.GetFinalizers()) == 0 || instance.GetFinalizers()[0] != finalizerName {
 		return nil
 	}
+	var RbacResources = mf.Any(mf.ByKind("Role"), mf.ByKind("ClusterRole"), mf.ByKind("RoleBinding"), mf.ByKind("ClusterRoleBinding"))
 	if len(r.servings) == 0 {
 		if err := r.config.Filter(mf.ByKind("Deployment")).Delete(); err != nil {
 			return err
 		}
-		if err := r.config.Filter(mf.NoCRDs).Delete(); err != nil {
+		if err := r.config.Filter(mf.All(mf.NoCRDs, mf.None(RbacResources))).Delete(); err != nil {
+			return err
+		}
+		// Delete Roles last, as they may be granting us permissions that are necessary.
+	        if err := r.config.Filter(RbacResources).Delete(); err != nil {
 			return err
 		}
 	}

--- a/pkg/reconciler/knativeserving/knativeserving_controller.go
+++ b/pkg/reconciler/knativeserving/knativeserving_controller.go
@@ -246,16 +246,16 @@ func (r *Reconciler) delete(instance *servingv1alpha1.KnativeServing) error {
 	if len(instance.GetFinalizers()) == 0 || instance.GetFinalizers()[0] != finalizerName {
 		return nil
 	}
-	var RbacResources = mf.Any(mf.ByKind("Role"), mf.ByKind("ClusterRole"), mf.ByKind("RoleBinding"), mf.ByKind("ClusterRoleBinding"))
+	var RBAC = mf.Any(mf.ByKind("Role"), mf.ByKind("ClusterRole"), mf.ByKind("RoleBinding"), mf.ByKind("ClusterRoleBinding"))
 	if len(r.servings) == 0 {
 		if err := r.config.Filter(mf.ByKind("Deployment")).Delete(); err != nil {
 			return err
 		}
-		if err := r.config.Filter(mf.All(mf.NoCRDs, mf.None(RbacResources))).Delete(); err != nil {
+		if err := r.config.Filter(mf.All(mf.NoCRDs, mf.None(RBAC))).Delete(); err != nil {
 			return err
 		}
-		// Delete Roles last, as they may be granting us permissions that are necessary.
-		if err := r.config.Filter(RbacResources).Delete(); err != nil {
+		// Delete Roles last, as they may be useful for human operators to clean up.
+		if err := r.config.Filter(RBAC).Delete(); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This allows us to take advantage of the permissions granted to cluster admins
when performing cleanup. If the approach in https://github.com/knative/serving-operator/pull/291
is approved, this will become necessary. Additionally, it makes sense to remove roles as the final
step to allow human Operators to modify any resources they may have permissions on as a result of the Knative installation (that is, we should not remove any access until we are 'almost done' cleaning up).

/lint

## Proposed Changes

* Delete roles and rolebindings as a final cleanup step.

**Release Note**

```release-note
Delete roles and rolebindings as a final cleanup step.
```
