### PR TITLE
Abide by first rule of structural schemas

### DIFF
--- a/config/300-serving-v1alpha1-knativeserving-crd.yaml
+++ b/config/300-serving-v1alpha1-knativeserving-crd.yaml
@@ -38,6 +38,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      type: object
       description: Schema for the knativeservings API
       properties:
         apiVersion:


### PR DESCRIPTION
A non-empty type for the root is required per
https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#specifying-a-structural-schema

Otherwise, the following status condition appears in the CRD on a
1.16+ cluster:

  - lastTransitionTime: "2020-03-17T16:58:54Z"
    message: 'spec.validation.openAPIV3Schema.type: Required value: must not be empty
      at the root'
    reason: Violations
    status: "True"
    type: NonStructuralSchema

