### PR TITLE
Enable 'kubectl explain knativeserving' to work

### DIFF
--- a/config/300-serving-v1alpha1-knativeserving-crd.yaml
+++ b/config/300-serving-v1alpha1-knativeserving-crd.yaml
@@ -33,6 +33,7 @@ spec:
     listKind: KnativeServingList
     plural: knativeservings
     singular: knativeserving
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}


### PR DESCRIPTION
Alternatively, we could convert this v1beta1 CRD to v1.
