### PR TITLE
Add nil check as well as IsNotFound check

### DIFF
--- a/test/resources/verify.go
+++ b/test/resources/verify.go
@@ -212,7 +212,7 @@ func KSOperatorCRDelete(t *testing.T, clients *test.Clients, names test.Resource
 
 	// verify all but the CRD's and the Namespace are gone
 	for _, u := range m.Filter(mf.NoCRDs, mf.None(mf.ByKind("Namespace"))).Resources() {
-		if _, err := m.Client.Get(&u); !apierrs.IsNotFound(err) {
+		if _, err := m.Client.Get(&u); err != nil && !apierrs.IsNotFound(err) {
 			t.Fatalf("The %s %s failed to be deleted: %v", u.GetKind(), u.GetName(), err)
 		}
 	}


### PR DESCRIPTION
## Proposed Changes

This patch adds nil check as well as `!apierrs.IsNotFound`.

Without it TestKnativeServingDeployment gets following failed status when the resources do not exist.

```
    --- FAIL: TestKnativeServingDeployment/delete (10.37s)
        verify.go:216: The ClusterRole knative-serving-admin failed to be deleted: <nil>
```

/lint

You can refer to [the logs](https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/185/pull-ci-openshift-knative-serverless-operator-master-4.3-e2e-aws-ocp-43/531), which happened on OpenShift CI.

**Release Note**

```release-note
NONE
```
