### PR TITLE
Print log message when start deleting resources

### DIFF
--- a/pkg/reconciler/knativeserving/knativeserving_controller.go
+++ b/pkg/reconciler/knativeserving/knativeserving_controller.go
@@ -246,6 +246,7 @@ func (r *Reconciler) delete(instance *servingv1alpha1.KnativeServing) error {
 	if len(instance.GetFinalizers()) == 0 || instance.GetFinalizers()[0] != finalizerName {
 		return nil
 	}
+	r.Logger.Info("Deleting resources")
 	var RBAC = mf.Any(mf.ByKind("Role"), mf.ByKind("ClusterRole"), mf.ByKind("RoleBinding"), mf.ByKind("ClusterRoleBinding"))
 	if len(r.servings) == 0 {
 		if err := r.config.Filter(mf.ByKind("Deployment")).Delete(); err != nil {


### PR DESCRIPTION
## Proposed Changes

This patch makes a tiny change to add log message when operator
deletes resources.

Currently there are no logs so it is difficult to debug when resources
are not deleted.

After this patch:
```
{"level":"info","ts":"2020-03-23T05:36:28.296Z","logger":"serving-operator.knativeserving-controller","caller":"knativeserving/knativeserving_controller.go:249","msg":"Deleting resources","commit":"d558b3a","knative.dev/controller":"knativeserving-controller"}
```

/lint

**Release Note**

```release-note
NONE
```
