### PR TITLE
Install from the manifest in a strict(er) order.

### DIFF
--- a/pkg/reconciler/knativeserving/knativeserving_controller.go
+++ b/pkg/reconciler/knativeserving/knativeserving_controller.go
@@ -207,7 +207,7 @@ func (r *Reconciler) install(manifest *mf.Manifest, instance *servingv1alpha1.Kn
 		instance.Status.MarkInstallFailed(err.Error())
 		return err
 	}
-	if err := manifest.Filter(mf.None(mf.Any(role, rolebinding))).Apply(); err != nil {
+	if err := manifest.Apply(); err != nil {
 		instance.Status.MarkInstallFailed(err.Error())
 		return err
 	}

--- a/pkg/reconciler/knativeserving/knativeserving_controller.go
+++ b/pkg/reconciler/knativeserving/knativeserving_controller.go
@@ -48,7 +48,7 @@ const (
 )
 
 var (
-	role mf.Predicate = mf.Any(mf.ByKind("ClusterRole"), mf.ByKind("Role"))
+	role        mf.Predicate = mf.Any(mf.ByKind("ClusterRole"), mf.ByKind("Role"))
 	rolebinding mf.Predicate = mf.Any(mf.ByKind("ClusterRoleBinding"), mf.ByKind("RoleBinding"))
 )
 


### PR DESCRIPTION
This order, Roles -> RoleBindings -> The Rest, prevents the operand from
needing to structure their manifest such that this ordering exists, while
allowing the Operator to use the bootstrapping mechanism described in
https://github.com/knative/serving-operator/pull/291 to 'escalate' itself
into management of the Knative Serving installation without a *** clusterrole.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Install roles, then rolebindings, then the remainder of the manifest.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE

```
