### PR TITLE
Add aliok as one approver of knative operator

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,6 +4,7 @@ approvers:
 - houshengbo
 - jcrossley3
 - trshafer
+- aliok
 - evankanderson  # TOC member as backup
 - mattmoor       # TOC member as backup
 
@@ -13,3 +14,4 @@ reviewers:
 - jcrossley3
 - trshafer
 - yu2003w
+- aliok


### PR DESCRIPTION
Ali has done amazing work, even since he did not officially joined the Knative
community.

He is leading the effort in operator's release in operatorhub, contributing
across any aspects, testing the operators against multiple scenarios.

His strong review has also acted as a good goalkeeper of our repository.

Based on his general contribution during the past3 months, I would like
to add his as an approver.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
