### PR TITLE
Change the install url to <version>.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To install a released version of the operator go and download the latest
 (`kubectl apply -f serving-operator.yaml`), or directly run:
 
 ```
-kubectl apply -f https://github.com/knative/serving-operator/releases/download/v0.10.0/serving-operator.yaml
+kubectl apply -f https://github.com/knative/serving-operator/releases/download/<version>/serving-operator.yaml
 ```
 
 2. Install the


### PR DESCRIPTION

## Proposed Changes

* Change the install url to <version>. Consistent with the official website documents. https://knative.dev/docs/install/knative-with-operators/

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```
